### PR TITLE
Fix effect reruns in currency converter

### DIFF
--- a/app/tools/currency-converter/currency-converter-client.tsx
+++ b/app/tools/currency-converter/currency-converter-client.tsx
@@ -58,7 +58,7 @@ export default function CurrencyConverterClient() {
     }
 
     loadRates();
-  }, [base, target]);
+  }, [base]);
 
   const handleAmount = (e: ChangeEvent<HTMLInputElement>) =>
     setAmount(Number(e.target.value));


### PR DESCRIPTION
## Summary
- fetch exchange rates only when the base currency changes

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_686e538e145483258ba2176ced35c957