### PR TITLE
Fix build by disabling font download and cleaning up

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -44,6 +44,11 @@ export const metadata = {
   },
 };
 
-export default function ContactPage() {
-  return <ContactClient />;
+import { Suspense } from "react";
+
+export default function ContactPage() {  return (
+    <Suspense>
+      <ContactClient />
+    </Suspense>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,11 +2,8 @@
 
 import "./globals.css";
 import { ReactNode } from "react";
-import { Inter } from "next/font/google";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-
-const inter = Inter({ subsets: ["latin"], display: "swap" });
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -73,7 +70,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${inter.className} bg-white text-gray-900 antialiased scroll-smooth`}
+      className="bg-white text-gray-900 antialiased scroll-smooth"
       suppressHydrationWarning
     >
       <body className="flex min-h-screen flex-col">
@@ -103,5 +100,4 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Footer />
       </body>
     </html>
-  );
-}
+  );}

--- a/app/tools/pdf-to-word/pdf-to-word-client.tsx
+++ b/app/tools/pdf-to-word/pdf-to-word-client.tsx
@@ -10,7 +10,6 @@ import {
   TextContent,
   TextItem,
 } from "pdfjs-dist/legacy/build/pdf";
-import "pdfjs-dist/legacy/build/pdf.worker.entry";
 
 // use the exported version on GlobalWorkerOptions
 GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${GlobalWorkerOptions.version}/pdf.worker.min.js`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NEXT_FONT_DOWNLOAD_DISABLE=1 next build",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- stop downloading Google Fonts during build
- remove unused pdf.js worker import
- fix Contact page Suspense usage
- drop `next/font/google` from layout to avoid network downloads

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e647dd7ec832589222bf25cd7f868