### PR TITLE
Add AdSense and GA scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Ads & Analytics](#ads--analytics)
 - [Project Structure](#project-structure)
 - [License](#license)
 - [Contact](#contact)
@@ -26,6 +27,12 @@ After installation run `npm run dev` and open <http://localhost:3000> in your br
 ### Metadata Guidelines
 
 Each page exports a `metadata` object to define `<title>`, description and social tags. Use semantic headings (H1 → H2…) and keep URLs canonical via the `alternates` field.
+
+### Ads & Analytics
+
+Google AdSense and Google Analytics load once globally using Next.js `next/script`
+with the `afterInteractive` strategy. This avoids CORS errors and ensures both
+scripts appear in every page's `<head>`.
 
 ### Testing
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { ReactNode } from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import AnalyticsScripts from "@/components/AnalyticsScripts";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -73,6 +74,19 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       className="bg-white text-gray-900 antialiased scroll-smooth"
       suppressHydrationWarning
     >
+      <head>
+        <link
+          rel="preconnect"
+          href="https://pagead2.googlesyndication.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preconnect"
+          href="https://www.googletagmanager.com"
+          crossOrigin="anonymous"
+        />
+        <AnalyticsScripts />
+      </head>
       <body className="flex min-h-screen flex-col">
         {/* Accessible skip link */}
         <a

--- a/components/AnalyticsScripts.tsx
+++ b/components/AnalyticsScripts.tsx
@@ -1,0 +1,27 @@
+'use client'
+import Script from "next/script";
+
+export default function AnalyticsScripts() {
+  return (
+    <>
+      <Script
+        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
+        strategy="afterInteractive"
+        crossOrigin="anonymous"
+        onError={(e) => console.error("AdSense load error:", e)}
+      />
+      <Script
+        src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"
+        strategy="afterInteractive"
+      />
+      <Script id="gtag-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-V74SWZ9H8B', { anonymize_ip: true });
+        `}
+      </Script>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- inject Google AdSense and GA via `next/script` using a client component
- preconnect to Google domains in the global layout
- document ads and analytics usage in README

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686eaf9837d08325b0f20fb4ed71cf77