### PR TITLE
Fix Google scripts integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Run the production build to ensure pages compile correctly:
 npm run build
 ```
 
+### Ads & Analytics
+
+Google AdSense and Google Analytics are loaded globally via the `next/script`
+component inside `app/layout.tsx`. Scripts are injected with the
+`afterInteractive` strategy so they execute client-side without causing CORS or
+content security errors.
+
 ## Project Structure
 
 ```bash

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -75,19 +75,34 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
     >
       <head>
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
+        <link
+          rel="preconnect"
+          href="https://pagead2.googlesyndication.com"
           crossOrigin="anonymous"
         />
-        {/* Google tag (gtag.js) */}
-        <Script async src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B" />
-        <Script
-          id="ga-inline"
-          dangerouslySetInnerHTML={{
-            __html: `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-V74SWZ9H8B');`,
-          }}
+        <link
+          rel="preconnect"
+          href="https://www.googletagmanager.com"
+          crossOrigin="anonymous"
         />
+        <Script
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
+          strategy="afterInteractive"
+          crossOrigin="anonymous"
+          onError={(e) => console.error("AdSense load error:", e)}
+        />
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"
+          strategy="afterInteractive"
+        />
+        <Script id="gtag-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-V74SWZ9H8B', { anonymize_ip: true });
+          `}
+        </Script>
       </head>
       <body className="flex min-h-screen flex-col">
         {/* Accessible skip link */}


### PR DESCRIPTION
## Summary
- inject AdSense and Analytics with `<Script>`
- document ads and analytics usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ec27311fc832584c7af8cac1903ca