### PR TITLE
Integrate analytics and basic e2e testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,52 @@ npm run build
 
 ### Ads & Analytics
 
-Google AdSense and Google Analytics are loaded globally via the `next/script`
-component inside `app/layout.tsx`. Scripts are injected with the
-`afterInteractive` strategy so they execute client-side without causing CORS or
-content security errors.
+Google AdSense and Google Analytics are injected into the `<head>` of every
+page through `app/components/AnalyticsLoader.tsx`.  The loader renders the
+following snippets exactly as provided by Google using Next.js `Script`
+components:
+
+```html
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-V74SWZ9H8B');
+</script>
+
+<script async
+        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
+        crossorigin="anonymous"></script>
+```
+
+To disable analytics or ads, remove `AnalyticsLoader` from `app/layout.tsx`.
+
+### Build & Deploy
+
+Create a production build and start the server:
+
+```bash
+npm run build
+npm start
+```
+
+### Running Tests
+
+Unit tests use [uvu](https://github.com/lukeed/uvu):
+
+```bash
+npm test
+```
+
+End-to-end tests are written with [Playwright](https://playwright.dev/):
+
+```bash
+npm run test:e2e
+```
+
+Install browsers once with `npx playwright install`.
 
 ## Project Structure
 

--- a/app/components/AnalyticsLoader.tsx
+++ b/app/components/AnalyticsLoader.tsx
@@ -4,27 +4,24 @@ import Script from "next/script";
 export default function AnalyticsLoader() {
   return (
     <>
-      <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossOrigin="anonymous" />
-      <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
-
       <Script
-        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
-        strategy="afterInteractive"
-        crossOrigin="anonymous"
-      />
-
-      <Script
+        async
         src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"
-        strategy="afterInteractive"
       />
-      <Script id="gtag-init" strategy="afterInteractive">
+      <Script id="gtag-init">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', 'G-V74SWZ9H8B', { anonymize_ip: true });
+          gtag('config', 'G-V74SWZ9H8B');
         `}
       </Script>
+
+      <Script
+        async
+        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
+        crossOrigin="anonymous"
+      />
     </>
   );
 }

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+// Simple check that the homepage renders and has expected heading
+
+test('homepage loads', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page.getByRole('heading', { name: 'Gearizen' })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-icons": "^5.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.41.2",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/bcryptjs": "^2.4.6",
         "@types/diff": "^7.0.2",
@@ -52,7 +53,7 @@
         "uvu": "^0.5.6"
       },
       "engines": {
-        "node": ">=18 <21"
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1842,6 +1843,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -7376,6 +7393,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",
     "test": "tsx node_modules/uvu/bin.js app/tools '\\.test\\.ts$'",
+    "test:e2e": "playwright test",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -54,7 +55,8 @@
     "tailwindcss": "^4.0.1",
     "tsx": "^4.7.0",
     "typescript": "^5.8.3",
-    "uvu": "^0.5.6"
+    "uvu": "^0.5.6",
+    "@playwright/test": "^1.41.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md}": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: true,
+    timeout: 120 * 1000,
+  },
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});


### PR DESCRIPTION
## Summary
- inject Google Analytics and AdSense snippets via `AnalyticsLoader`
- document analytics integration and build/test steps
- add Playwright and sample e2e test

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ecab23c00832583cc58b6ae31bdc3