### PR TITLE
Fix analytics script loading

### DIFF
--- a/app/components/AnalyticsLoader.tsx
+++ b/app/components/AnalyticsLoader.tsx
@@ -7,8 +7,9 @@ export default function AnalyticsLoader() {
       <Script
         async
         src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"
+        strategy="afterInteractive"
       />
-      <Script id="gtag-init">
+      <Script id="gtag-init" strategy="afterInteractive">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
@@ -21,6 +22,7 @@ export default function AnalyticsLoader() {
         async
         src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
         crossOrigin="anonymous"
+        strategy="afterInteractive"
       />
     </>
   );


### PR DESCRIPTION
## Summary
- load gtag and adsbygoogle snippets `afterInteractive` to avoid CSP errors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ecf63bfdc8325bed8d5dca6b0e9da