### PR TITLE
Fix CORS for ads scripts and add tool tests

### DIFF
--- a/app/components/AnalyticsLoader.tsx
+++ b/app/components/AnalyticsLoader.tsx
@@ -14,14 +14,15 @@ export default function AnalyticsLoader() {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', 'G-V74SWZ9H8B');
+          gtag('config', 'G-V74SWZ9H8B', {
+            cookie_flags: 'SameSite=None;Secure'
+          });
         `}
       </Script>
 
       <Script
         async
         src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
-        crossOrigin="anonymous"
         strategy="afterInteractive"
       />
     </>

--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+
+// automatically generate tests for each tool page
+test.describe('tool pages', () => {
+  const dirs = fs.readdirSync('app/tools');
+  dirs.forEach(dir => {
+    if (dir === 'page.tsx' || dir === 'tools-client.tsx') return;
+    const pagePath = `app/tools/${dir}/page.tsx`;
+    if (fs.existsSync(pagePath)) {
+      test(`${dir} page renders`, async ({ page }) => {
+        await page.goto(`/tools/${dir}`);
+        await expect(page.locator('h1')).toBeVisible();
+      });
+    }
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,27 @@
 import type { NextConfig } from "next";
 
+const ContentSecurityPolicy =
+  "default-src 'self'; " +
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com; " +
+  "img-src 'self' data: https://www.google-analytics.com https://pagead2.googlesyndication.com; " +
+  "style-src 'self' 'unsafe-inline'; " +
+  "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; " +
+  "frame-src https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com;";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: ContentSecurityPolicy.replace(/\n/g, ' '),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- allow Google analytics and ads scripts by defining security headers
- remove CORS attribute from AdSense loader and set cookie flags
- add Playwright e2e tests for all tool pages

## Testing
- `npm run lint`
- `npm test`
- `npm run type-check`
- `npm run build`
- `npm run test:e2e` *(fails: missing browsers due to blocked downloads)*

------
https://chatgpt.com/codex/tasks/task_e_686ed709d288832586bf1ef7a5a66461