### PR TITLE
Fix GA & AdSense integration

### DIFF
--- a/app/components/AnalyticsLoader.tsx
+++ b/app/components/AnalyticsLoader.tsx
@@ -8,6 +8,7 @@ export default function AnalyticsLoader() {
         async
         src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"
         strategy="afterInteractive"
+        crossOrigin="anonymous"
       />
       <Script id="gtag-init" strategy="afterInteractive">
         {`
@@ -15,7 +16,8 @@ export default function AnalyticsLoader() {
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', 'G-V74SWZ9H8B', {
-            cookie_flags: 'SameSite=None;Secure'
+            cookie_flags: 'SameSite=None;Secure',
+            cookie_expires: 63072000
           });
         `}
       </Script>
@@ -24,6 +26,7 @@ export default function AnalyticsLoader() {
         async
         src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
         strategy="afterInteractive"
+        crossOrigin="anonymous"
       />
     </>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,6 +78,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://www.googletagmanager.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <meta name="google-adsense-account" content="ca-pub-2108375251131552" />
         <AnalyticsLoader />
       </head>
       <body className="flex min-h-screen flex-col">

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+// smoke test for Google Analytics and AdSense loading
+
+test('analytics and ads load', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await page.waitForLoadState('networkidle');
+  const gtagDefined = await page.evaluate(() => typeof window.gtag === 'function');
+  expect(gtagDefined).toBeTruthy();
+  const adsResponse = await page.request.get('https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js');
+  expect(adsResponse.status()).toBe(200);
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const ContentSecurityPolicy =
   "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com; " +
   "img-src 'self' data: https://www.google-analytics.com https://pagead2.googlesyndication.com; " +
   "style-src 'self' 'unsafe-inline'; " +
-  "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; " +
+  "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com; " +
   "frame-src https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com;";
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary
- adjust Google Analytics script to set cookie expiration
- load gtag and adsbygoogle with `crossOrigin="anonymous"`
- expose AdSense account via meta tag
- allow AdSense network in CSP headers
- add Playwright smoke test for analytics

## Testing
- `npm run lint`
- `npm run test`
- `npm run test:e2e` *(fails: browser install blocked)*
- `PW_SKIP_BROWSER_DOWNLOAD=1 npm run build`
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_686edf14b464832589fca49ef467bffc