### PR TITLE
Fix analytics cookie flags & allow AdSense scripts

### DIFF
--- a/app/components/AnalyticsLoader.tsx
+++ b/app/components/AnalyticsLoader.tsx
@@ -16,8 +16,10 @@ export default function AnalyticsLoader() {
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', 'G-V74SWZ9H8B', {
-            // two year cookie lifetime
-            cookie_expires: 63072000
+            // two year cookie lifetime via Max-Age
+            cookie_expires: 63072000,
+            // ensure third-party cookies use SameSite=None and Secure
+            cookie_flags: 'SameSite=None;Secure'
           });
         `}
       </Script>

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,10 @@ import type { NextConfig } from "next";
 // Content Security Policy allowing Google Analytics and AdSense assets
 const ContentSecurityPolicy =
   "default-src 'self'; " +
-  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com; " +
-  "img-src 'self' data: https://www.google-analytics.com https://pagead2.googlesyndication.com; " +
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://securepubads.g.doubleclick.net; " +
+  "img-src 'self' data: https://www.google-analytics.com https://pagead2.googlesyndication.com https://securepubads.g.doubleclick.net; " +
   "style-src 'self' 'unsafe-inline'; " +
-  "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com; " +
+  "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://securepubads.g.doubleclick.net; " +
   "frame-src https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com;";
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary
- allow AdSense via doubleclick in CSP
- set Google Analytics cookie flags for SameSite=None; Secure

## Testing
- `npm test`
- `npx playwright install --with-deps` *(fails: cdn.playwright.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686eee63e3a48325862c1b8ac7ce167f