### PR TITLE
Fix analytics script loading and CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,23 +44,34 @@ npm run build
 ### Ads & Analytics
 
 Google AdSense and Google Analytics are injected into the `<head>` of every
-page through `app/components/AnalyticsLoader.tsx`.  The loader renders the
-following snippets exactly as provided by Google using Next.js `Script`
-components:
+page through `app/components/AnalyticsLoader.tsx`. The loader uses Next.js
+`Script` components so external assets load without CORS or CSP issues:
 
-```html
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-V74SWZ9H8B');
-</script>
+```tsx
+<Script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"
+  strategy="afterInteractive"
+  crossOrigin="anonymous"
+/>
+<Script id="gtag-init" strategy="afterInteractive">
+  {`
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-V74SWZ9H8B', {
+      cookie_expires: 63072000,
+      cookie_flags: 'SameSite=None;Secure'
+    });
+  `}
+</Script>
 
-<script async
-        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
-        crossorigin="anonymous"></script>
+<Script
+  async
+  src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
+  strategy="afterInteractive"
+  crossOrigin="anonymous"
+/>
 ```
 
 To disable analytics or ads, remove `AnalyticsLoader` from `app/layout.tsx`.

--- a/app/components/AnalyticsLoader.tsx
+++ b/app/components/AnalyticsLoader.tsx
@@ -17,7 +17,9 @@ export default function AnalyticsLoader() {
           gtag('js', new Date());
           gtag('config', 'G-V74SWZ9H8B', {
             // two year cookie lifetime
-            cookie_expires: 63072000
+            cookie_expires: 63072000,
+            // set cross-site cookie flags for analytics
+            cookie_flags: 'SameSite=None;Secure'
           });
         `}
       </Script>

--- a/app/components/JsonLd.tsx
+++ b/app/components/JsonLd.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+import Script from "next/script";
 
 export default function JsonLd({ data }: { data: Record<string, unknown> }) {
   return (
-    <script
+    <Script
+      id="json-ld"
       type="application/ld+json"
+      // use Next.js Script to satisfy CSP
+      strategy="afterInteractive"
       dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
     />
   );

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -13,7 +13,7 @@ test('analytics and ads load', async ({ page, context }) => {
   await page.goto('/');
   await page.waitForLoadState('networkidle');
 
-  const gtagDefined = await page.evaluate(() => typeof window.gtag === 'function');
+  const gtagDefined = await page.evaluate(() => typeof (window as any).gtag === 'function');
   expect(gtagDefined).toBeTruthy();
 
   const adsResponse = await page.request.get(

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,7 @@ const ContentSecurityPolicy =
   "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com; " +
   "img-src 'self' data: https://www.google-analytics.com https://pagead2.googlesyndication.com; " +
   "style-src 'self' 'unsafe-inline'; " +
-  "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com; " +
+  "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://api.exchangerate.host; " +
   "frame-src https://googleads.g.doubleclick.net https://pagead2.googlesyndication.com;";
 
 const nextConfig: NextConfig = {
@@ -23,6 +23,9 @@ const nextConfig: NextConfig = {
         headers: securityHeaders,
       },
     ];
+  },
+  images: {
+    domains: ['www.google-analytics.com', 'pagead2.googlesyndication.com'],
   },
 };
 


### PR DESCRIPTION
## Summary
- allow exchange rate host in CSP and expose images domain
- load JSON-LD with Next.js `Script`
- set `cookie_flags` for GA and update README snippet
- tweak Playwright test to avoid TS error

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686eee63e3a48325862c1b8ac7ce167f