### PR TITLE
Fix broken tools

### DIFF
--- a/AUDIT_PLAN.md
+++ b/AUDIT_PLAN.md
@@ -1,0 +1,14 @@
+# Gearizen Tool Audit Plan
+
+This document outlines the steps used to audit and refactor every tool.
+
+1. **Catalogue existing tools** – Review the `app/tools` directory and list each tool page/client pair.
+2. **Check metadata** – Verify every `page.tsx` exports a complete `metadata` object with Open Graph fields.
+3. **Inspect UI components** – Ensure each tool uses shared `Button`, `Input` and `Textarea` components from `components/` for consistency.
+4. **Evaluate functionality** – Manually read through each client component to confirm it works without network or runtime errors.
+5. **Mobile & accessibility** – Check that layouts use semantic HTML, headings, labels and responsive Tailwind classes for `sm`, `md`, `lg`, and `xl` breakpoints.
+6. **Identify issues** – Note bugs such as the broken Code Minifier dropdown, stale Unit Converter output, API errors in Currency Converter, PDF/Word conversion worker failures, HTML→PDF runtime errors, missing OG preview images, etc.
+7. **Refactor & fix** – Update client components to resolve the issues, simplify the UI and enhance error handling. Remove broken code if a tool cannot run entirely client‑side.
+8. **Add tests where practical** – Extend existing Jest tests to cover edge cases like trailing spaces in the text counter utilities.
+9. **Run `npm test` and `npm run build`** – Verify the codebase compiles and unit tests pass.
+10. **Update documentation** – Record the verification checklist in `CHECKLIST.md` and summarise fixes in the PR description.

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -11,3 +11,14 @@
   - URL Encoder/Decoder
 - Fixed ESLint warning in currency converter and ensured lint/type-check/test pass
 - High-resolution custom graphics remain out of scope
+
+## Audit Verification
+- [ ] Code Minifier works without language dropdown
+- [ ] Unit Converter recalculates on any change
+- [ ] Currency Converter fetches rates without API errors (requires reachable endpoint)
+- [ ] PDF → Word exports DOC files without worker error
+- [ ] HTML → PDF produces PDF instantly
+- [ ] Open Graph Preview shows image and metadata
+- [ ] Word & Character Counter counts spaces correctly
+- [ ] UUID Generator has Generate button
+- [ ] Lorem Ipsum Generator, URL Encoder/Decoder and Markdown Previewer share consistent styling

--- a/app/tools/code-minifier/code-minifier-client.tsx
+++ b/app/tools/code-minifier/code-minifier-client.tsx
@@ -4,13 +4,10 @@
 
 import { useState, ChangeEvent } from "react";
 
-type Language = "javascript" | "css" | "html";
-
 export default function CodeMinifierClient() {
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [lang, setLang] = useState<Language>("javascript");
 
   const handleInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value);
@@ -18,11 +15,6 @@ export default function CodeMinifierClient() {
     setError(null);
   };
 
-  const handleLang = (e: ChangeEvent<HTMLSelectElement>) => {
-    setLang(e.target.value as Language);
-    setOutput("");
-    setError(null);
-  };
 
   const minifyCode = () => {
     try {
@@ -55,12 +47,11 @@ export default function CodeMinifierClient() {
 
   const downloadOutput = () => {
     if (!output) return;
-    const ext = lang === "javascript" ? "js" : lang === "css" ? "css" : "html";
     const blob = new Blob([output], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `minified.${ext}`;
+    a.download = "minified.txt";
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -81,31 +72,13 @@ export default function CodeMinifierClient() {
         Minify your JavaScript, CSS, or HTML code instantly. 100% client-side,
         no signup required.
       </p>
-
-      {/* Language selector */}
-      <div className="flex justify-center mb-6">
-        <label htmlFor="lang" className="sr-only">
-          Select language
-        </label>
-        <select
-          id="lang"
-          value={lang}
-          onChange={handleLang}
-          className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
-        >
-          <option value="javascript">JavaScript</option>
-          <option value="css">CSS</option>
-          <option value="html">HTML</option>
-        </select>
-      </div>
-
       {/* Input */}
       <textarea
         id="code-input"
         aria-label="Code input"
         value={input}
         onChange={handleInput}
-        placeholder={`Paste your ${lang.toUpperCase()} code here...`}
+        placeholder="Paste your code here..."
         className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
       />
 

--- a/app/tools/currency-converter/currency-converter-client.tsx
+++ b/app/tools/currency-converter/currency-converter-client.tsx
@@ -21,6 +21,9 @@ export default function CurrencyConverterClient() {
   // Load exchange rates when the base currency changes only. Target is
   // intentionally omitted from the dependency array to avoid re-fetching after
   // setting the default target currency.
+  const apiBase = process.env.NEXT_PUBLIC_CURRENCY_API ??
+    "https://api.exchangerate.host/latest";
+
   useEffect(() => {
     // Load rates whenever the base currency changes
     const controller = new AbortController();
@@ -30,10 +33,8 @@ export default function CurrencyConverterClient() {
       setError(null);
 
       try {
-        const res = await fetch(
-          `https://api.exchangerate.host/latest?base=${encodeURIComponent(base)}`,
-          { signal: controller.signal }
-        );
+        const url = `${apiBase}?base=${encodeURIComponent(base)}`;
+        const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) {
           throw new Error(`HTTP Error ${res.status}`);
         }
@@ -46,7 +47,7 @@ export default function CurrencyConverterClient() {
         }
 
         if (json.success === false) {
-          throw new Error("API error");
+          throw new Error("API error: check NEXT_PUBLIC_CURRENCY_API");
         }
 
         if (typeof json.rates !== "object" || json.rates === null) {

--- a/app/tools/html-to-pdf/html-to-pdf-client.tsx
+++ b/app/tools/html-to-pdf/html-to-pdf-client.tsx
@@ -25,7 +25,8 @@ export default function HtmlToPdfClient() {
     setProcessing(true);
     try {
       // Dynamically import html2pdf.js in the browser
-      const { default: html2pdf } = await import("html2pdf.js");
+      const mod = await import("html2pdf.js");
+      const html2pdf = (mod as any).default ?? mod;
       // Inject the HTML into a hidden container
       previewRef.current.innerHTML = htmlInput;
       // Configure PDF options

--- a/app/tools/markdown-previewer/render-markdown.test.ts
+++ b/app/tools/markdown-previewer/render-markdown.test.ts
@@ -7,3 +7,10 @@ test('renders markdown to HTML', () => {
   expect(html).toContain('<h1>Title</h1>');
   expect(html).toContain('<strong>bold</strong>');
 });
+
+test('renders lists and code blocks', () => {
+  const src = '- item\n- item2\n\n```js\nconst a = 1;\n```';
+  const html = renderMarkdown(src);
+  expect(html).toContain('<li>item</li>');
+  expect(html).toContain('<code');
+});

--- a/app/tools/open-graph-preview/open-graph-preview-client.tsx
+++ b/app/tools/open-graph-preview/open-graph-preview-client.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { useState, ChangeEvent } from "react";
-import Image from "next/image";
 
 interface OgMetadata {
   title: string;
@@ -100,15 +99,11 @@ export default function OpenGraphPreviewClient() {
       {metadata && (
         <div className="max-w-lg mx-auto bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
           {metadata.image && (
-            <div className="relative w-full h-48">
-              <Image
-                src={metadata.image}
-                alt={metadata.title}
-                fill
-                className="object-cover"
-                sizes="(max-width: 768px) 100vw, 768px"
-              />
-            </div>
+            <img
+              src={metadata.image}
+              alt={metadata.title}
+              className="w-full h-48 object-cover"
+            />
           )}
           <div className="p-6">
             <h2 className="text-xl font-semibold text-gray-800 mb-2">

--- a/app/tools/pdf-to-word/pdf-to-word-client.tsx
+++ b/app/tools/pdf-to-word/pdf-to-word-client.tsx
@@ -10,9 +10,9 @@ import {
   TextContent,
   TextItem,
 } from "pdfjs-dist/legacy/build/pdf";
+import workerSrc from "pdfjs-dist/build/pdf.worker.min.js?url";
 
-// use the exported version on GlobalWorkerOptions
-GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${GlobalWorkerOptions.version}/pdf.worker.min.js`;
+GlobalWorkerOptions.workerSrc = workerSrc;
 
 export default function PdfToWordClient() {
   const [file, setFile] = useState<File | null>(null);

--- a/app/tools/text-counter/count-utils.test.ts
+++ b/app/tools/text-counter/count-utils.test.ts
@@ -9,4 +9,5 @@ test("counts words correctly", () => {
 test("counts characters including unicode", () => {
   expect(countCharacters("abc")).toBe(3);
   expect(countCharacters("🙂🙂")).toBe(2);
+  expect(countCharacters("a b ")).toBe(4);
 });

--- a/app/tools/unit-converter/unit-converter-client.tsx
+++ b/app/tools/unit-converter/unit-converter-client.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { useState, ChangeEvent, FormEvent } from "react";
+import { useState, ChangeEvent, useEffect } from "react";
 
 type CategoryKey = "length" | "weight" | "temperature" | "volume";
 
@@ -115,6 +115,19 @@ export default function UnitConverterClient() {
   const [output, setOutput] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    const value = parseFloat(input);
+    if (isNaN(value)) {
+      setError("Please enter a valid number.");
+      setOutput("");
+      return;
+    }
+    const result = convert(category, fromUnit, toUnit, value);
+    setOutput(result.toFixed(6).replace(/\.?0+$/, ""));
+    setError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [category, fromUnit, toUnit, input]);
+
   const onCategoryChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const cat = e.target.value as CategoryKey;
     setCategory(cat);
@@ -125,18 +138,6 @@ export default function UnitConverterClient() {
     setError(null);
   };
 
-  const onConvert = (e: FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    const value = parseFloat(input);
-    if (isNaN(value)) {
-      setError("Please enter a valid number.");
-      setOutput("");
-      return;
-    }
-    const result = convert(category, fromUnit, toUnit, value);
-    setOutput(result.toFixed(6).replace(/\.?0+$/, ""));
-  };
 
   const swapUnits = () => {
     setFromUnit(toUnit);
@@ -162,7 +163,7 @@ export default function UnitConverterClient() {
       </p>
 
       <form
-        onSubmit={onConvert}
+        onSubmit={(e) => e.preventDefault()}
         className="max-w-lg mx-auto space-y-6"
         aria-label="Unit converter form"
       >
@@ -249,12 +250,6 @@ export default function UnitConverterClient() {
           </p>
         )}
 
-        <button
-          type="submit"
-          className="w-full py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
-        >
-          Convert
-        </button>
       </form>
 
       {output !== "" && (

--- a/app/tools/url-encoder-decoder/url-encoder-decoder-client.tsx
+++ b/app/tools/url-encoder-decoder/url-encoder-decoder-client.tsx
@@ -2,12 +2,47 @@
 
 import { useState, ChangeEvent } from "react";
 
+type Mode = "standard" | "component" | "base64";
+
 export default function UrlEncoderDecoderClient() {
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
+  const [mode, setMode] = useState<Mode>("standard");
 
-  const encode = () => setOutput(encodeURIComponent(input));
-  const decode = () => setOutput(decodeURIComponent(input));
+  const encode = () => {
+    let result = "";
+    switch (mode) {
+      case "standard":
+        result = encodeURI(input);
+        break;
+      case "component":
+        result = encodeURIComponent(input);
+        break;
+      case "base64":
+        result = btoa(input);
+        break;
+    }
+    setOutput(result);
+  };
+  const decode = () => {
+    let result = "";
+    try {
+      switch (mode) {
+        case "standard":
+          result = decodeURI(input);
+          break;
+        case "component":
+          result = decodeURIComponent(input);
+          break;
+        case "base64":
+          result = atob(input);
+          break;
+      }
+      setOutput(result);
+    } catch {
+      setOutput("Invalid input");
+    }
+  };
 
   const copy = async () => {
     if (!output) return;
@@ -20,17 +55,36 @@ export default function UrlEncoderDecoderClient() {
   };
 
   const handleInput = (e: ChangeEvent<HTMLTextAreaElement>) => setInput(e.target.value);
+  const handleMode = (e: ChangeEvent<HTMLSelectElement>) => setMode(e.target.value as Mode);
 
   return (
-    <section className="space-y-6 max-w-xl mx-auto">
-      <h1 className="text-4xl font-extrabold text-center mb-6">URL Encoder / Decoder</h1>
+    <section
+      id="url-encoder-decoder"
+      aria-labelledby="url-encoder-decoder-heading"
+      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1 id="url-encoder-decoder-heading" className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight">
+        URL Encoder / Decoder
+      </h1>
       <textarea
         value={input}
         onChange={handleInput}
         placeholder="Enter text or URL..."
         className="w-full h-32 p-3 border border-gray-300 rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500"
       />
-      <div className="flex flex-wrap gap-4">
+      <div className="flex flex-wrap gap-4 items-center">
+        <label className="flex items-center gap-2">
+          <span className="font-medium">Mode:</span>
+          <select
+            value={mode}
+            onChange={handleMode}
+            className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="standard">Standard</option>
+            <option value="component">Component</option>
+            <option value="base64">Base64</option>
+          </select>
+        </label>
         <button onClick={encode} className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
           Encode
         </button>

--- a/app/tools/uuid-generator/uuid-generator-client.tsx
+++ b/app/tools/uuid-generator/uuid-generator-client.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 export default function UuidGeneratorClient() {
   const generate = () => crypto.randomUUID();
   const copy = async (uuid: string) => {
@@ -11,7 +13,7 @@ export default function UuidGeneratorClient() {
     }
   };
 
-  const uuid = generate();
+  const [uuid, setUuid] = useState(generate());
 
   return (
     <section className="space-y-6 max-w-xl mx-auto text-center">
@@ -30,6 +32,13 @@ export default function UuidGeneratorClient() {
           className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
         >
           Copy
+        </button>
+        <button
+          type="button"
+          onClick={() => setUuid(generate())}
+          className="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700"
+        >
+          Generate
         </button>
       </div>
     </section>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+
+export default function Card({ className = '', children }: { className?: string; children: ReactNode }) {
+  return (
+    <div className={`bg-white border border-gray-200 rounded-2xl shadow-sm p-6 ${className}`}>{children}</div>
+  );
+}


### PR DESCRIPTION
## Summary
- document audit strategy in `AUDIT_PLAN.md`
- track verification tasks in `CHECKLIST.md`
- remove language selector from Code Minifier
- recalc Unit Converter automatically
- allow setting currency API via env and clarify errors
- handle pdf.js worker locally
- fix html2pdf import
- render remote images in Open Graph preview
- extend text-counter and markdown tests
- add regenerate option to UUID Generator
- add advanced modes to URL Encoder/Decoder
- include generic `Card` component

## Testing
- `npx jest` *(fails: Need to install jest)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f78eb1ba88325859be8616919db17