### PR TITLE
Fix tool functionality

### DIFF
--- a/app/tools/code-minifier/code-minifier-client.tsx
+++ b/app/tools/code-minifier/code-minifier-client.tsx
@@ -4,22 +4,13 @@
 
 import { useState, ChangeEvent } from "react";
 
-type Language = "javascript" | "css" | "html";
-
 export default function CodeMinifierClient() {
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [lang, setLang] = useState<Language>("javascript");
 
   const handleInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value);
-    setOutput("");
-    setError(null);
-  };
-
-  const handleLang = (e: ChangeEvent<HTMLSelectElement>) => {
-    setLang(e.target.value as Language);
     setOutput("");
     setError(null);
   };
@@ -55,12 +46,11 @@ export default function CodeMinifierClient() {
 
   const downloadOutput = () => {
     if (!output) return;
-    const ext = lang === "javascript" ? "js" : lang === "css" ? "css" : "html";
     const blob = new Blob([output], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `minified.${ext}`;
+    a.download = `minified.txt`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -82,30 +72,13 @@ export default function CodeMinifierClient() {
         no signup required.
       </p>
 
-      {/* Language selector */}
-      <div className="flex justify-center mb-6">
-        <label htmlFor="lang" className="sr-only">
-          Select language
-        </label>
-        <select
-          id="lang"
-          value={lang}
-          onChange={handleLang}
-          className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
-        >
-          <option value="javascript">JavaScript</option>
-          <option value="css">CSS</option>
-          <option value="html">HTML</option>
-        </select>
-      </div>
-
       {/* Input */}
       <textarea
         id="code-input"
         aria-label="Code input"
         value={input}
         onChange={handleInput}
-        placeholder={`Paste your ${lang.toUpperCase()} code here...`}
+        placeholder="Paste your code here..."
         className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
       />
 

--- a/app/tools/currency-converter/currency-converter-client.tsx
+++ b/app/tools/currency-converter/currency-converter-client.tsx
@@ -30,10 +30,10 @@ export default function CurrencyConverterClient() {
       setError(null);
 
       try {
-        const res = await fetch(
-          `https://api.exchangerate.host/latest?base=${encodeURIComponent(base)}`,
-          { signal: controller.signal }
-        );
+        const api = process.env.NEXT_PUBLIC_RATES_URL ||
+          "https://api.exchangerate.host/latest";
+        const url = `${api}?base=${encodeURIComponent(base)}`;
+        const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) {
           throw new Error(`HTTP Error ${res.status}`);
         }

--- a/app/tools/html-to-pdf/html-to-pdf-client.tsx
+++ b/app/tools/html-to-pdf/html-to-pdf-client.tsx
@@ -25,7 +25,7 @@ export default function HtmlToPdfClient() {
     setProcessing(true);
     try {
       // Dynamically import html2pdf.js in the browser
-      const { default: html2pdf } = await import("html2pdf.js");
+      const html2pdf = (await import("html2pdf.js")).default;
       // Inject the HTML into a hidden container
       previewRef.current.innerHTML = htmlInput;
       // Configure PDF options

--- a/app/tools/open-graph-preview/open-graph-preview-client.tsx
+++ b/app/tools/open-graph-preview/open-graph-preview-client.tsx
@@ -103,7 +103,7 @@ export default function OpenGraphPreviewClient() {
             <div className="relative w-full h-48">
               <Image
                 src={metadata.image}
-                alt={metadata.title}
+                alt={metadata.title || "Preview image"}
                 fill
                 className="object-cover"
                 sizes="(max-width: 768px) 100vw, 768px"

--- a/app/tools/pdf-to-word/pdf-to-word-client.tsx
+++ b/app/tools/pdf-to-word/pdf-to-word-client.tsx
@@ -10,9 +10,10 @@ import {
   TextContent,
   TextItem,
 } from "pdfjs-dist/legacy/build/pdf";
+import workerSrc from "pdfjs-dist/legacy/build/pdf.worker.entry?url";
 
-// use the exported version on GlobalWorkerOptions
-GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${GlobalWorkerOptions.version}/pdf.worker.min.js`;
+// use bundled worker instead of CDN to avoid network errors
+GlobalWorkerOptions.workerSrc = workerSrc;
 
 export default function PdfToWordClient() {
   const [file, setFile] = useState<File | null>(null);

--- a/app/tools/unit-converter/unit-converter-client.tsx
+++ b/app/tools/unit-converter/unit-converter-client.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { useState, ChangeEvent, FormEvent } from "react";
+import { useState, ChangeEvent, FormEvent, useEffect } from "react";
 
 type CategoryKey = "length" | "weight" | "temperature" | "volume";
 
@@ -127,6 +127,10 @@ export default function UnitConverterClient() {
 
   const onConvert = (e: FormEvent) => {
     e.preventDefault();
+    recalc();
+  };
+
+  const recalc = () => {
     setError(null);
     const value = parseFloat(input);
     if (isNaN(value)) {
@@ -137,6 +141,11 @@ export default function UnitConverterClient() {
     const result = convert(category, fromUnit, toUnit, value);
     setOutput(result.toFixed(6).replace(/\.?0+$/, ""));
   };
+
+  useEffect(() => {
+    recalc();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [category, fromUnit, toUnit, input]);
 
   const swapUnits = () => {
     setFromUnit(toUnit);

--- a/app/tools/url-encoder-decoder/url-encoder-decoder-client.tsx
+++ b/app/tools/url-encoder-decoder/url-encoder-decoder-client.tsx
@@ -5,9 +5,24 @@ import { useState, ChangeEvent } from "react";
 export default function UrlEncoderDecoderClient() {
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
+  const [mode, setMode] = useState("standard");
 
-  const encode = () => setOutput(encodeURIComponent(input));
-  const decode = () => setOutput(decodeURIComponent(input));
+  const encode = () => {
+    if (mode === "base64") {
+      setOutput(btoa(input));
+    } else if (mode === "component") {
+      setOutput(encodeURI(input));
+    } else {
+      setOutput(encodeURIComponent(input));
+    }
+  };
+  const decode = () => {
+    if (mode === "base64") {
+      try { setOutput(atob(input)); } catch { setOutput("Invalid base64") }
+    } else {
+      setOutput(decodeURIComponent(input));
+    }
+  };
 
   const copy = async () => {
     if (!output) return;
@@ -30,7 +45,19 @@ export default function UrlEncoderDecoderClient() {
         placeholder="Enter text or URL..."
         className="w-full h-32 p-3 border border-gray-300 rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500"
       />
-      <div className="flex flex-wrap gap-4">
+      <div className="flex flex-wrap gap-4 items-end">
+        <label className="text-sm font-medium">
+          Mode:
+          <select
+            value={mode}
+            onChange={(e) => setMode(e.target.value)}
+            className="ml-2 border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="standard">Standard</option>
+            <option value="component">Component Safe</option>
+            <option value="base64">Base64</option>
+          </select>
+        </label>
         <button onClick={encode} className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
           Encode
         </button>

--- a/app/tools/uuid-generator/uuid-generator-client.tsx
+++ b/app/tools/uuid-generator/uuid-generator-client.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 export default function UuidGeneratorClient() {
   const generate = () => crypto.randomUUID();
   const copy = async (uuid: string) => {
@@ -11,7 +13,7 @@ export default function UuidGeneratorClient() {
     }
   };
 
-  const uuid = generate();
+  const [uuid, setUuid] = useState<string>(generate());
 
   return (
     <section className="space-y-6 max-w-xl mx-auto text-center">
@@ -26,8 +28,15 @@ export default function UuidGeneratorClient() {
         />
         <button
           type="button"
-          onClick={() => copy(uuid)}
+          onClick={() => setUuid(generate())}
           className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        >
+          Generate
+        </button>
+        <button
+          type="button"
+          onClick={() => copy(uuid)}
+          className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500"
         >
           Copy
         </button>


### PR DESCRIPTION
## Summary
- remove language selector from Code Minifier
- auto-recalculate Unit Converter when inputs change
- allow currency API endpoint override
- bundle pdf.js worker locally
- ensure html2pdf dynamic import works
- improve OG preview image alt text
- add Generate button for UUID Generator
- add encoding modes for URL Encoder/Decoder

## Testing
- `npm test` *(fails: Could not load "sharp" module)*
- `npm run build` *(fails: ENETUNREACH download swc)*

------
https://chatgpt.com/codex/tasks/task_e_686f7da5c1408325ad9f8739687af963