### PR TITLE
Fix script crossOrigin and page export formatting

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -48,4 +48,5 @@ export const metadata = {
 };
 
 export default function AboutPage() {
-  return <AboutClient />;}
+  return <AboutClient />;
+}

--- a/app/components/AnalyticsLoader.tsx
+++ b/app/components/AnalyticsLoader.tsx
@@ -8,6 +8,7 @@ export default function AnalyticsLoader() {
         async
         src="https://www.googletagmanager.com/gtag/js?id=G-V74SWZ9H8B"
         strategy="afterInteractive"
+        crossOrigin="anonymous"
       />
       <Script id="gtag-init" strategy="afterInteractive">
         {`
@@ -22,6 +23,7 @@ export default function AnalyticsLoader() {
         async
         src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2108375251131552"
         strategy="afterInteractive"
+        crossOrigin="anonymous"
       />
     </>
   );

--- a/app/cookies/page.tsx
+++ b/app/cookies/page.tsx
@@ -47,4 +47,5 @@ export const metadata = {
 };
 
 export default function CookiePage() {
-  return <CookiesClient />;}
+  return <CookiesClient />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -76,8 +76,16 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="preconnect" href="https://www.googletagmanager.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          rel="preconnect"
+          href="https://www.googletagmanager.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
         <meta name="google-adsense-account" content="ca-pub-2108375251131552" />
         <AnalyticsLoader />
       </head>
@@ -108,4 +116,5 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Footer />
       </body>
     </html>
-  );}
+  );
+}

--- a/app/not-found/page.tsx
+++ b/app/not-found/page.tsx
@@ -45,4 +45,5 @@ export const metadata = {
 };
 
 export default function NotFoundPage() {
-  return <NotFoundClient />;}
+  return <NotFoundClient />;
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -46,4 +46,5 @@ export const metadata = {
 };
 
 export default function PrivacyPage() {
-  return <PrivacyClient />;}
+  return <PrivacyClient />;
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -45,4 +45,5 @@ export const metadata = {
 };
 
 export default function TermsPage() {
-  return <TermsClient />;}
+  return <TermsClient />;
+}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -67,5 +67,6 @@ export const metadata = {
   },
 };
 
-export default function ToolsPage() {  return <ToolsClient />;
+export default function ToolsPage() {
+  return <ToolsClient />;
 }


### PR DESCRIPTION
## Summary
- add `crossOrigin` attribute to external analytics scripts and preconnect links
- clean up page exports for about, cookies, privacy, terms, not-found and tools pages

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_686fd8f3bf64832583a2dfc4348f4a0e