### PR TITLE
Refactor tools for fully client-side UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run dev
 
 ## Usage
 
-After installation run `npm run dev` and open <http://localhost:3000> in your browser.
+After installation run `npm run dev` and open <http://localhost:3000> in your browser. All tools run entirely client-side with no external APIs.
 
 ### Metadata Guidelines
 
@@ -44,9 +44,9 @@ npm run build
 ### Ads & Analytics
 
 Google AdSense and Google Analytics are injected into the `<head>` of every
-page through `app/components/AnalyticsLoader.tsx`.  The loader renders the
-following snippets exactly as provided by Google using Next.js `Script`
-components:
+page through `app/components/AnalyticsLoader.tsx`.  Replace the IDs below with
+your own if deploying a fork. The loader renders the following snippets exactly
+as provided by Google using Next.js `Script` components:
 
 ```html
 <!-- Google tag (gtag.js) -->

--- a/app/contact/contact-client.tsx
+++ b/app/contact/contact-client.tsx
@@ -1,56 +1,13 @@
-// app/contact/contact-client.tsx
 "use client";
-
 import { useSearchParams } from "next/navigation";
-import { FormEvent, useRef, useState } from "react";
 
 export default function ContactClient() {
-  const searchParams = useSearchParams();
-  const success = searchParams.get("success") === "1";
-  const formRef = useRef<HTMLFormElement>(null);
-
-  const [formData, setFormData] = useState({
-    name: "",
-    email: "",
-    message: "",
-  });
-  const [errors, setErrors] = useState<Partial<typeof formData>>({});
-
-  function validate() {
-    const errs: Partial<typeof formData> = {};
-    if (!formData.name.trim()) errs.name = "Name is required.";
-    if (!formData.email.trim()) {
-      errs.email = "Email is required.";
-    } else if (
-      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)
-    ) {
-      errs.email = "Please enter a valid email address.";
-    }
-    if (!formData.message.trim()) errs.message = "Message is required.";
-    setErrors(errs);
-    return Object.keys(errs).length === 0;
-  }
-
-  function handleChange(
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) {
-    setFormData((p) => ({ ...p, [e.target.name]: e.target.value }));
-    setErrors((p) => ({ ...p, [e.target.name]: undefined }));
-  }
-
-  function handleSubmit(e: FormEvent) {
-    if (!validate()) {
-      e.preventDefault();
-      return;
-    }
-    // allow native form submit to Formspree
-  }
-
+  const success = useSearchParams().get("success") === "1";
   return (
     <section
       id="contact-gearizen"
       aria-labelledby="contact-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased"
+      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900"
     >
       <h1
         id="contact-heading"
@@ -58,130 +15,20 @@ export default function ContactClient() {
       >
         Contact Us
       </h1>
-      <p className="text-lg text-gray-700 mb-12 max-w-xl mx-auto leading-relaxed text-center">
-        Have questions, feedback or tool suggestions? Send us a message and we&#39;ll get back to you shortly.
+      <p className="text-lg text-gray-700 mb-12 max-w-xl mx-auto text-center">
+        Have questions or feedback? Please email us at
+        <a href="mailto:gearizen.tahir.ozcan@gmail.com" className="text-indigo-600 underline ml-1">
+          gearizen.tahir.ozcan@gmail.com
+        </a>
+        .
       </p>
-
-      {success ? (
+      {success && (
         <div
           role="status"
           className="max-w-md mx-auto bg-green-50 border border-green-200 text-green-800 p-6 rounded-lg text-center"
         >
           <p className="font-medium text-lg">Thank you! Your message has been sent.</p>
         </div>
-      ) : (
-        <form
-          ref={formRef}
-          action="https://formspree.io/f/xwpbdrlj"
-          method="POST"
-          noValidate
-          onSubmit={handleSubmit}
-          className="max-w-md mx-auto space-y-6"
-        >
-          {/* redirect back with success=1 */}
-          <input
-            type="hidden"
-            name="_next"
-            value="https://gearizen.com/contact?success=1"
-          />
-
-          <div>
-            <label
-              htmlFor="name"
-              className="block text-sm font-medium text-gray-800 mb-1"
-            >
-              Name <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="name"
-              name="name"
-              type="text"
-              value={formData.name}
-              onChange={handleChange}
-              placeholder="Your name"
-              required
-              className={`w-full border rounded-lg px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 transition ${
-                errors.name
-                  ? "border-red-500 focus:ring-red-500"
-                  : "border-gray-300 focus:ring-indigo-500"
-              }`}
-              aria-invalid={!!errors.name}
-              aria-describedby={errors.name ? "error-name" : undefined}
-            />
-            {errors.name && (
-              <p id="error-name" className="mt-1 text-sm text-red-600">
-                {errors.name}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-gray-800 mb-1"
-            >
-              Email <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="email"
-              name="email"
-              type="email"
-              value={formData.email}
-              onChange={handleChange}
-              placeholder="you@example.com"
-              required
-              className={`w-full border rounded-lg px-4 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 transition ${
-                errors.email
-                  ? "border-red-500 focus:ring-red-500"
-                  : "border-gray-300 focus:ring-indigo-500"
-              }`}
-              aria-invalid={!!errors.email}
-              aria-describedby={errors.email ? "error-email" : undefined}
-            />
-            {errors.email && (
-              <p id="error-email" className="mt-1 text-sm text-red-600">
-                {errors.email}
-              </p>
-            )}
-          </div>
-
-          <div>
-            <label
-              htmlFor="message"
-              className="block text-sm font-medium text-gray-800 mb-1"
-            >
-              Message <span className="text-red-500">*</span>
-            </label>
-            <textarea
-              id="message"
-              name="message"
-              rows={6}
-              value={formData.message}
-              onChange={handleChange}
-              placeholder="Write your message here..."
-              required
-              className={`w-full border rounded-lg px-4 py-2 placeholder-gray-400 resize-y focus:outline-none focus:ring-2 transition ${
-                errors.message
-                  ? "border-red-500 focus:ring-red-500"
-                  : "border-gray-300 focus:ring-indigo-500"
-              }`}
-              aria-invalid={!!errors.message}
-              aria-describedby={errors.message ? "error-message" : undefined}
-            />
-            {errors.message && (
-              <p id="error-message" className="mt-1 text-sm text-red-600">
-                {errors.message}
-              </p>
-            )}
-          </div>
-
-          <button
-            type="submit"
-            className="w-full inline-flex justify-center items-center bg-indigo-600 text-white font-semibold rounded-lg px-6 py-3 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
-          >
-            Send Message
-          </button>
-        </form>
       )}
     </section>
   );

--- a/app/tools/image-compressor/image-compressor-client.tsx
+++ b/app/tools/image-compressor/image-compressor-client.tsx
@@ -18,24 +18,21 @@ export default function ImageCompressorClient() {
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
 
-  // When a file is selected update the preview and reset previous results
   useEffect(() => {
     if (!file) return;
-    const url = URL.createObjectURL(file);
-    setOriginalUrl(url);
-    setOriginalSize(file.size);
-    if (compressedUrl) {
-      URL.revokeObjectURL(compressedUrl);
-    }
-    setCompressedUrl(null);
-    setCompressedSize(null);
-    setError(null);
-    return () => {
-      URL.revokeObjectURL(url);
+    const reader = new FileReader();
+    reader.onload = () => {
+      setOriginalUrl(reader.result as string);
+      setOriginalSize(file.size);
+      setError(null);
     };
-  }, [file, compressedUrl]);
+    reader.readAsDataURL(file);
+  }, [file]);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (compressedUrl) URL.revokeObjectURL(compressedUrl);
+    setCompressedUrl(null);
+    setCompressedSize(null);
     setFile(e.target.files?.[0] ?? null);
   };
 
@@ -46,7 +43,6 @@ export default function ImageCompressorClient() {
 
     // Load the image from the selected file
     const img = new window.Image();
-    img.crossOrigin = 'anonymous';
     img.src = originalUrl;
 
     img.onload = () => {

--- a/app/tools/image-resizer/image-resizer-client.tsx
+++ b/app/tools/image-resizer/image-resizer-client.tsx
@@ -18,17 +18,18 @@ export default function ImageResizerClient() {
   // Orijinal boyutları tutmak için ref
   const naturalSize = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
 
-  // Dosya seçildiğinde preview URL oluştur, cleanup yap
   useEffect(() => {
     if (!file) {
       setOriginalUrl(null);
       return;
     }
-    const url = URL.createObjectURL(file);
-    setOriginalUrl(url);
-    setResizedUrl(null);
-    setError(null);
-    return () => URL.revokeObjectURL(url);
+    const reader = new FileReader();
+    reader.onload = () => {
+      setOriginalUrl(reader.result as string);
+      setResizedUrl(null);
+      setError(null);
+    };
+    reader.readAsDataURL(file);
   }, [file]);
 
   // Görsel yeniden boyutlandırma işlevi

--- a/app/tools/unit-converter/unit-converter-client.tsx
+++ b/app/tools/unit-converter/unit-converter-client.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { useState, ChangeEvent, FormEvent } from "react";
+import { useState, ChangeEvent, useEffect } from "react";
 
 type CategoryKey = "length" | "weight" | "temperature" | "volume";
 
@@ -125,18 +125,20 @@ export default function UnitConverterClient() {
     setError(null);
   };
 
-  const onConvert = (e: FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    const value = parseFloat(input);
-    if (isNaN(value)) {
-      setError("Please enter a valid number.");
-      setOutput("");
-      return;
-    }
-    const result = convert(category, fromUnit, toUnit, value);
-    setOutput(result.toFixed(6).replace(/\.?0+$/, ""));
-  };
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const value = parseFloat(input);
+      if (isNaN(value)) {
+        setError("Please enter a valid number.");
+        setOutput("");
+        return;
+      }
+      setError(null);
+      const result = convert(category, fromUnit, toUnit, value);
+      setOutput(result.toFixed(6).replace(/\.?0+$/, ""));
+    }, 300);
+    return () => clearTimeout(t);
+  }, [category, fromUnit, toUnit, input]);
 
   const swapUnits = () => {
     setFromUnit(toUnit);
@@ -162,7 +164,7 @@ export default function UnitConverterClient() {
       </p>
 
       <form
-        onSubmit={onConvert}
+        onSubmit={(e) => e.preventDefault()}
         className="max-w-lg mx-auto space-y-6"
         aria-label="Unit converter form"
       >
@@ -248,13 +250,6 @@ export default function UnitConverterClient() {
             {error}
           </p>
         )}
-
-        <button
-          type="submit"
-          className="w-full py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
-        >
-          Convert
-        </button>
       </form>
 
       {output !== "" && (

--- a/types/pdfjs-dist.d.ts
+++ b/types/pdfjs-dist.d.ts
@@ -24,6 +24,11 @@ declare module "pdfjs-dist/legacy/build/pdf" {
      * The result contains an array of text items and optional styles map.
      */
     getTextContent(): Promise<TextContent>;
+    getViewport(params: { scale: number }): { width: number; height: number };
+    render(options: {
+      canvasContext: CanvasRenderingContext2D;
+      viewport: { width: number; height: number };
+    }): { promise: Promise<void> };
   }
 
   /** The result of .getTextContent(), containing text items and optional style definitions. */
@@ -90,3 +95,4 @@ declare module "pdfjs-dist/legacy/build/pdf" {
 /** The companion worker entrypoint. */
 declare module "pdfjs-dist/legacy/build/pdf.worker.entry";
 declare module "pdfjs-dist/legacy/build/pdf.worker.entry?url";
+declare module "pdfjs-dist/legacy/build/pdf.worker.entry?worker&url";


### PR DESCRIPTION
## Summary
- update contact page to use a mailto link instead of Formspree
- fix image compressor and resizer previews using FileReader
- make unit converter auto-convert with a debounce
- enhance PDF to Word tool with worker import and preview
- note client‑side usage in README
- add missing pdf.js worker type declarations

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e` *(fails: no browsers)*

------
https://chatgpt.com/codex/tasks/task_e_687030b61c408325887012f081e5a33e