### PR TITLE
Refactor UUID generator UI

### DIFF
--- a/app/tools/uuid-generator/page-client.tsx
+++ b/app/tools/uuid-generator/page-client.tsx
@@ -13,7 +13,9 @@ function uuidV4() {
 function uuidV1() {
   const now = Date.now();
   const timeLow = (now & 0xffffffff).toString(16).padStart(8, "0");
-  const timeMid = (((now / 0x100000000) & 0xffff) | 0).toString(16).padStart(4, "0");
+  const timeMid = (((now / 0x100000000) & 0xffff) | 0)
+    .toString(16)
+    .padStart(4, "0");
   const timeHiAndVersion = ((((now / 0x100000000) >> 16) & 0x0fff) | 0x1000)
     .toString(16)
     .padStart(4, "0");
@@ -68,7 +70,7 @@ export default function UuidGeneratorClient() {
     >
       <h1
         id="uuid-generator-heading"
-        className="text-4xl font-extrabold text-center mb-6 tracking-tight"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
       >
         Free UUID Generator
       </h1>
@@ -109,7 +111,9 @@ export default function UuidGeneratorClient() {
           </label>
 
           <label htmlFor="separator" className="flex items-center space-x-2">
-            <span className="text-sm font-medium text-gray-700">Separator:</span>
+            <span className="text-sm font-medium text-gray-700">
+              Separator:
+            </span>
             <select
               id="separator"
               value={separator}
@@ -130,7 +134,9 @@ export default function UuidGeneratorClient() {
               min={1}
               max={50}
               value={count}
-              onChange={(e) => setCount(Math.min(50, Math.max(1, Number(e.target.value))))}
+              onChange={(e) =>
+                setCount(Math.min(50, Math.max(1, Number(e.target.value))))
+              }
               className="input-base w-20 px-2 py-1 text-sm"
             />
           </label>
@@ -139,7 +145,7 @@ export default function UuidGeneratorClient() {
         <div className="flex flex-wrap gap-3">
           <button
             type="submit"
-            className="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition text-sm font-medium"
+            className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
           >
             Generate
           </button>

--- a/app/tools/uuid-generator/page.tsx
+++ b/app/tools/uuid-generator/page.tsx
@@ -27,7 +27,12 @@ export const metadata: Metadata = {
     locale: "en_US",
     type: "website",
     images: [
-      { url: "/og-placeholder.svg", width: 1200, height: 630, alt: "Gearizen UUID Generator" },
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen UUID Generator",
+      },
     ],
   },
   twitter: {
@@ -43,7 +48,10 @@ export const metadata: Metadata = {
 export default function UuidGeneratorPage() {
   return (
     <>
-      <BreadcrumbJsonLd pageTitle="Free UUID Generator" pageUrl="https://gearizen.com/tools/uuid-generator" />
+      <BreadcrumbJsonLd
+        pageTitle="Free UUID Generator"
+        pageUrl="https://gearizen.com/tools/uuid-generator"
+      />
       <UuidGeneratorClient />
     </>
   );


### PR DESCRIPTION
## Summary
- restyle UUID Generator heading for responsive typography
- make the Generate button use the indigo site-wide color
- format UUID Generator metadata

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68704c51d30c8325b9623cde73f00879