### PR TITLE
Unify tool page layout

### DIFF
--- a/app/tools/base64-encoder-decoder/base64-encoder-decoder-client.tsx
+++ b/app/tools/base64-encoder-decoder/base64-encoder-decoder-client.tsx
@@ -51,7 +51,7 @@ export default function Base64EncoderDecoderClient() {
     <section
       id="base64-encoder-decoder"
       aria-labelledby="base64-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="base64-heading"

--- a/app/tools/bcrypt-generator/bcrypt-generator-client.tsx
+++ b/app/tools/bcrypt-generator/bcrypt-generator-client.tsx
@@ -47,7 +47,7 @@ export default function BcryptGeneratorClient() {
     <section
       id="bcrypt-generator"
       aria-labelledby="bcrypt-generator-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="bcrypt-generator-heading"

--- a/app/tools/code-minifier/code-minifier-client.tsx
+++ b/app/tools/code-minifier/code-minifier-client.tsx
@@ -60,7 +60,7 @@ export default function CodeMinifierClient() {
     <section
       id="code-minifier"
       aria-labelledby="code-minifier-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="code-minifier-heading"

--- a/app/tools/color-contrast-checker/color-contrast-checker-client.tsx
+++ b/app/tools/color-contrast-checker/color-contrast-checker-client.tsx
@@ -67,7 +67,7 @@ export default function ColorContrastCheckerClient() {
     <section
       id="color-contrast-checker"
       aria-labelledby="contrast-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="contrast-heading"

--- a/app/tools/html-formatter/html-formatter-client.tsx
+++ b/app/tools/html-formatter/html-formatter-client.tsx
@@ -56,7 +56,7 @@ export default function HtmlFormatterClient() {
     <section
       id="html-formatter"
       aria-labelledby="html-formatter-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="html-formatter-heading"

--- a/app/tools/html-to-pdf/html-to-pdf-client.tsx
+++ b/app/tools/html-to-pdf/html-to-pdf-client.tsx
@@ -51,7 +51,7 @@ export default function HtmlToPdfClient() {
     <section
       id="html-to-pdf"
       aria-labelledby="html-to-pdf-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="html-to-pdf-heading"

--- a/app/tools/jwt-decoder/jwt-decoder-client.tsx
+++ b/app/tools/jwt-decoder/jwt-decoder-client.tsx
@@ -59,7 +59,7 @@ export default function JwtDecoderClient() {
     <section
       id="jwt-decoder"
       aria-labelledby="jwt-decoder-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="jwt-decoder-heading"

--- a/app/tools/markdown-to-html/markdown-to-html-client.tsx
+++ b/app/tools/markdown-to-html/markdown-to-html-client.tsx
@@ -53,7 +53,7 @@ export default function MarkdownToHtmlClient() {
     <section
       id="markdown-to-html"
       aria-labelledby="markdown-to-html-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="markdown-to-html-heading"

--- a/app/tools/pdf-compressor/pdf-compressor-client.tsx
+++ b/app/tools/pdf-compressor/pdf-compressor-client.tsx
@@ -116,7 +116,7 @@ export default function PdfCompressorClient() {
     <section
       id="pdf-compressor"
       aria-labelledby="pdf-compressor-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="pdf-compressor-heading"

--- a/app/tools/pdf-to-word/pdf-to-word-client.tsx
+++ b/app/tools/pdf-to-word/pdf-to-word-client.tsx
@@ -114,7 +114,7 @@ export default function PdfToWordClient() {
     <section
       id="pdf-to-word"
       aria-labelledby="pdf-to-word-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="pdf-to-word-heading"

--- a/app/tools/seo-meta-tag-generator/seo-meta-tag-generator-client.tsx
+++ b/app/tools/seo-meta-tag-generator/seo-meta-tag-generator-client.tsx
@@ -58,7 +58,7 @@ export default function SeoMetaTagGeneratorClient() {
     <section
       id="seo-meta-tag-generator"
       aria-labelledby="seo-meta-tag-generator-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="seo-meta-tag-generator-heading"

--- a/app/tools/text-counter/text-counter-client.tsx
+++ b/app/tools/text-counter/text-counter-client.tsx
@@ -14,7 +14,7 @@ export default function TextCounterClient() {
     <section
       id="text-counter"
       aria-labelledby="text-counter-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="text-counter-heading"

--- a/app/tools/text-diff/text-diff-client.tsx
+++ b/app/tools/text-diff/text-diff-client.tsx
@@ -48,7 +48,7 @@ export default function TextDiffClient() {
     <section
       id="text-diff"
       aria-labelledby="text-diff-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="text-diff-heading"

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -235,8 +235,11 @@ export default function ToolsClient() {
   );
 
   return (
-    <div className="bg-white text-gray-900 antialiased py-12 sm:py-16 lg:py-20">
-      <div className="container-responsive space-y-12">
+    <section
+      id="all-tools"
+      aria-labelledby="all-tools-heading"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900 space-y-12"
+    >
         {/* Hero */}
         <header className="text-center max-w-3xl mx-auto space-y-4">
           <h1 className="text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight">
@@ -292,7 +295,6 @@ export default function ToolsClient() {
             ))}
           </ul>
         </section>
-      </div>
-    </div>
+    </section>
   );
 }

--- a/app/tools/unit-converter/unit-converter-client.tsx
+++ b/app/tools/unit-converter/unit-converter-client.tsx
@@ -150,7 +150,7 @@ export default function UnitConverterClient() {
     <section
       id="unit-converter"
       aria-labelledby="unit-converter-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="unit-converter-heading"

--- a/app/tools/unix-timestamp-converter/unix-timestamp-converter-client.tsx
+++ b/app/tools/unix-timestamp-converter/unix-timestamp-converter-client.tsx
@@ -70,7 +70,7 @@ export default function UnixTimestampConverterClient() {
     <section
       id="unix-timestamp-converter"
       aria-labelledby="utc-heading"
-      className="container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="utc-heading"


### PR DESCRIPTION
## Summary
- use shared `container-responsive` grid on all tool pages
- convert Tools page to `section` wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687051307a608325a84599d23df555a6