### PR TITLE
Add global tool settings context

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,11 @@
 @import "tailwindcss";
+:root {
+  --tool-font-size: 16px;
+}
+input,
+textarea {
+  font-size: var(--tool-font-size);
+}
 @layer components {
   .btn-primary {
     @apply px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import AnalyticsLoader from "./components/AnalyticsLoader";
+import ToolProviders from "@/components/ToolProviders";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -89,30 +90,32 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <AnalyticsLoader />
       </head>
       <body className="flex min-h-screen flex-col">
-        {/* Accessible skip link */}
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md z-50"
-        >
-          Skip to main content
-        </a>
+        <ToolProviders>
+          {/* Accessible skip link */}
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md z-50"
+          >
+            Skip to main content
+          </a>
 
-        {/* Primary navigation */}
-        <Navbar />
+          {/* Primary navigation */}
+          <Navbar />
 
-        {/* Main content area */}
-        <main
-          id="main-content"
-          role="main"
-          tabIndex={-1}
-          aria-label="Main content"
-          className="flex-grow container-responsive py-8"
-        >
-          {children}
-        </main>
+          {/* Main content area */}
+          <main
+            id="main-content"
+            role="main"
+            tabIndex={-1}
+            aria-label="Main content"
+            className="flex-grow container-responsive py-8"
+          >
+            {children}
+          </main>
 
-        {/* Footer */}
-        <Footer />
+          {/* Footer */}
+          <Footer />
+        </ToolProviders>
       </body>
     </html>
   );

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -1,9 +1,10 @@
 import { InputHTMLAttributes } from 'react';
 
-export default function Input({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+export default function Input({ className = '', style, ...props }: InputHTMLAttributes<HTMLInputElement>) {
   return (
     <input
       {...props}
+      style={{ ...style, fontSize: 'var(--tool-font-size)' }}
       className={`input-base ${className}`}
     />
   );

--- a/components/Textarea.tsx
+++ b/components/Textarea.tsx
@@ -1,9 +1,10 @@
 import { TextareaHTMLAttributes } from 'react';
 
-export default function Textarea({ className = '', ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+export default function Textarea({ className = '', style, ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
   return (
     <textarea
       {...props}
+      style={{ ...style, fontSize: 'var(--tool-font-size)' }}
       className={`input-base p-4 ${className}`}
     />
   );

--- a/components/ToolProviders.tsx
+++ b/components/ToolProviders.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ReactNode } from "react";
+import { ToolSettingsProvider } from "./ToolSettingsContext";
+import ToolSettingsPanel from "./ToolSettingsPanel";
+import { useState } from "react";
+
+export default function ToolProviders({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <ToolSettingsProvider>
+      {children}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="fixed bottom-4 right-4 z-50 px-3 py-2 bg-indigo-600 text-white rounded-full shadow-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        aria-label="Toggle tool settings"
+      >
+        ⚙️
+      </button>
+      {open && (
+        <div className="fixed bottom-16 right-4 z-50">
+          <ToolSettingsPanel />
+        </div>
+      )}
+    </ToolSettingsProvider>
+  );
+}
+

--- a/components/ToolSettingsContext.tsx
+++ b/components/ToolSettingsContext.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+export interface ToolSettings {
+  theme: string;
+  fontSize: number;
+  inputFormat: string;
+  outputFormat: string;
+}
+
+const defaultSettings: ToolSettings = {
+  theme: "light",
+  fontSize: 16,
+  inputFormat: "text",
+  outputFormat: "text",
+};
+
+interface ToolSettingsContextValue {
+  settings: ToolSettings;
+  updateSettings: (updates: Partial<ToolSettings>) => void;
+}
+
+const ToolSettingsContext = createContext<ToolSettingsContextValue>({
+  settings: defaultSettings,
+  updateSettings: () => {},
+});
+
+export function ToolSettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<ToolSettings>(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem("tool-settings");
+        if (stored) return { ...defaultSettings, ...JSON.parse(stored) };
+      } catch {
+        // ignore
+      }
+    }
+    return defaultSettings;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem("tool-settings", JSON.stringify(settings));
+    document.documentElement.style.setProperty(
+      "--tool-font-size",
+      `${settings.fontSize}px`
+    );
+  }, [settings]);
+
+  const updateSettings = (updates: Partial<ToolSettings>) => {
+    setSettings((prev) => ({ ...prev, ...updates }));
+  };
+
+  return (
+    <ToolSettingsContext.Provider value={{ settings, updateSettings }}>
+      {children}
+    </ToolSettingsContext.Provider>
+  );
+}
+
+export function useToolSettings() {
+  return useContext(ToolSettingsContext);
+}
+

--- a/components/ToolSettingsPanel.tsx
+++ b/components/ToolSettingsPanel.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useToolSettings } from "./ToolSettingsContext";
+import { ChangeEvent } from "react";
+
+export default function ToolSettingsPanel() {
+  const { settings, updateSettings } = useToolSettings();
+
+  const onFontSize = (e: ChangeEvent<HTMLInputElement>) => {
+    updateSettings({ fontSize: Number(e.target.value) });
+  };
+
+  const onInputFormat = (e: ChangeEvent<HTMLSelectElement>) => {
+    updateSettings({ inputFormat: e.target.value });
+  };
+
+  const onOutputFormat = (e: ChangeEvent<HTMLSelectElement>) => {
+    updateSettings({ outputFormat: e.target.value });
+  };
+
+  return (
+    <form className="space-y-4 p-4 bg-gray-50 border border-gray-200 rounded-lg max-w-sm" aria-label="Tool settings">
+      <div>
+        <label htmlFor="font-size" className="block text-sm font-medium text-gray-700">
+          Font Size
+        </label>
+        <input
+          id="font-size"
+          type="number"
+          min={12}
+          max={24}
+          value={settings.fontSize}
+          onChange={onFontSize}
+          className="input-base mt-1"
+        />
+      </div>
+      <div>
+        <label htmlFor="input-format" className="block text-sm font-medium text-gray-700">
+          Input Format
+        </label>
+        <select
+          id="input-format"
+          value={settings.inputFormat}
+          onChange={onInputFormat}
+          className="input-base mt-1"
+        >
+          <option value="text">Text</option>
+          <option value="json">JSON</option>
+          <option value="base64">Base64</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="output-format" className="block text-sm font-medium text-gray-700">
+          Output Format
+        </label>
+        <select
+          id="output-format"
+          value={settings.outputFormat}
+          onChange={onOutputFormat}
+          className="input-base mt-1"
+        >
+          <option value="text">Text</option>
+          <option value="json">JSON</option>
+          <option value="base64">Base64</option>
+        </select>
+      </div>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `ToolSettingsContext` with provider and hook
- create floating `ToolSettingsPanel` via `ToolProviders`
- wrap layout with provider and panel toggle
- apply font-size variable to all inputs and textareas

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870533648a883258a5dc6cc8050e54d