### PR TITLE
Enhance SEO metadata and add breadcrumbs

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,7 @@
 // app/about/page.tsx
 
 import AboutClient from "./about-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -48,5 +49,13 @@ export const metadata = {
 };
 
 export default function AboutPage() {
-  return <AboutClient />;
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="About Us"
+        pageUrl="https://gearizen.com/about"
+      />
+      <AboutClient />
+    </>
+  );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,7 @@
 // app/contact/page.tsx
 
 import ContactClient from "./contact-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -49,8 +50,14 @@ import Spinner from "../../components/Spinner";
 
 export default function ContactPage() {
   return (
-    <Suspense fallback={<Spinner className="mx-auto mt-10" />}>
-      <ContactClient />
-    </Suspense>
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Contact Us"
+        pageUrl="https://gearizen.com/contact"
+      />
+      <Suspense fallback={<Spinner className="mx-auto mt-10" />}>
+        <ContactClient />
+      </Suspense>
+    </>
   );
 }

--- a/app/cookies/page.tsx
+++ b/app/cookies/page.tsx
@@ -1,6 +1,7 @@
 // app/cookies/page.tsx
 
 import CookiesClient from "./cookies-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -47,5 +48,13 @@ export const metadata = {
 };
 
 export default function CookiePage() {
-  return <CookiesClient />;
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Cookie Policy"
+        pageUrl="https://gearizen.com/cookies"
+      />
+      <CookiesClient />
+    </>
+  );
 }

--- a/app/not-found/page.tsx
+++ b/app/not-found/page.tsx
@@ -1,6 +1,7 @@
 // app/not-found/page.tsx
 
 import NotFoundClient from "./not-found-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -45,5 +46,13 @@ export const metadata = {
 };
 
 export default function NotFoundPage() {
-  return <NotFoundClient />;
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="404 – Page Not Found"
+        pageUrl="https://gearizen.com/404"
+      />
+      <NotFoundClient />
+    </>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,8 @@ import {
 import JsonLd from "./components/JsonLd";
 
 export const metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  alternates: { canonical: "https://gearizen.com" },
   title: "Home | Gearizen – Free Client-Side Digital Tools",
   description:
     "Discover Gearizen’s most in-demand, privacy-first web tools: password generator, PDF to Word converter, QR code generator, unit converter and image compressor—100% client-side, no signup required.",
@@ -20,6 +22,9 @@ export const metadata = {
     description:
       "Explore Gearizen’s top tools—passwords, PDF to Word, QR codes, unit conversion and image compression—all privacy-first and signup-free.",
     url: "https://gearizen.com",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
     images: [
       {
         url: "/og-placeholder.svg",
@@ -28,6 +33,14 @@ export const metadata = {
         alt: "Gearizen Home",
       },
     ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Home | Gearizen – Free Client-Side Digital Tools",
+    description:
+      "Explore Gearizen’s top tools—passwords, PDF to Word, QR codes, unit conversion and image compression—all privacy-first and signup-free.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
   },
 };
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,6 +1,7 @@
 // app/privacy/page.tsx
 
 import PrivacyClient from "./privacy-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -46,5 +47,13 @@ export const metadata = {
 };
 
 export default function PrivacyPage() {
-  return <PrivacyClient />;
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Privacy Policy"
+        pageUrl="https://gearizen.com/privacy"
+      />
+      <PrivacyClient />
+    </>
+  );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,6 +1,7 @@
 // app/terms/page.tsx
 
 import TermsClient from "./terms-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -45,5 +46,13 @@ export const metadata = {
 };
 
 export default function TermsPage() {
-  return <TermsClient />;
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Terms of Use"
+        pageUrl="https://gearizen.com/terms"
+      />
+      <TermsClient />
+    </>
+  );
 }

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,6 +1,7 @@
 // app/tools/page.tsx
 
 import ToolsClient from "./tools-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -66,5 +67,13 @@ export const metadata = {
 };
 
 export default function ToolsPage() {
-  return <ToolsClient />;
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Free Online Tools"
+        pageUrl="https://gearizen.com/tools"
+      />
+      <ToolsClient />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- improve home page SEO metadata
- inject breadcrumb JSON-LD on static pages
- ensure Tools index page includes structured data

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870537ac414832594b5f61711b9d089