### PR TITLE
Fix Markdown preview image handling

### DIFF
--- a/app/tools/markdown-previewer/render-markdown.test.ts
+++ b/app/tools/markdown-previewer/render-markdown.test.ts
@@ -7,3 +7,13 @@ test('renders markdown to HTML', () => {
   expect(html).toContain('<h1>Title</h1>');
   expect(html).toContain('<strong>bold</strong>');
 });
+
+// Images using blob URLs should be preserved so local uploads show in the
+// preview. Relative paths are resolved against the current origin.
+test('renders images with blob and relative paths', () => {
+  const html = renderMarkdown('![](blob:abc)\n![](foo.png)');
+  expect(html).toContain('src="blob:abc"');
+  // Tests run in Node where window is undefined, so relative paths resolve to
+  // http://localhost/ by default.
+  expect(html).toContain('src="http://localhost/foo.png"');
+});

--- a/app/tools/markdown-previewer/render-markdown.ts
+++ b/app/tools/markdown-previewer/render-markdown.ts
@@ -1,6 +1,28 @@
 import { marked } from "marked";
 import DOMPurify from "isomorphic-dompurify";
 
+// Allow blob URLs so uploaded or generated images render in the preview.
+DOMPurify.setConfig({
+  ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|data|blob):|[^a-z]|[a-z+.-]+(?:[^a-z]|$))/i,
+});
+
+// Resolve relative image paths against the current page location so
+// Markdown like `![](./foo.png)` shows correctly in the preview.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'IMG') {
+    const src = node.getAttribute('src');
+    if (src && !/^(?:[a-z]+:|\/)/i.test(src)) {
+      try {
+        const base =
+          typeof window === 'undefined' ? 'http://localhost/' : window.location.href;
+        node.setAttribute('src', new URL(src, base).toString());
+      } catch {
+        /* noop */
+      }
+    }
+  }
+});
+
 // Renders markdown to sanitized HTML.
 // Configure marked once with GitHub-flavored markdown and line breaks so
 // the preview mirrors typical editors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@playwright/test": "^1.41.2",
         "@tailwindcss/postcss": "^4.1.11",
+        "@tailwindcss/typography": "^0.5.10",
         "@types/bcryptjs": "^2.4.6",
         "@types/diff": "^7.0.2",
         "@types/dompurify": "^3.0.5",
@@ -2870,6 +2871,22 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -4704,6 +4721,19 @@
       "license": "MIT",
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cssstyle": {
@@ -8801,6 +8831,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9924,6 +9968,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@playwright/test": "^1.41.2",
     "@tailwindcss/postcss": "^4.1.11",
+    "@tailwindcss/typography": "^0.5.10",
     "@types/bcryptjs": "^2.4.6",
     "@types/diff": "^7.0.2",
     "@types/dompurify": "^3.0.5",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('@tailwindcss/typography')],
+};


### PR DESCRIPTION
## Summary
- allow blob URLs in Markdown preview
- resolve relative image paths against current URL
- add tests for blob and relative images
- add Tailwind typography plugin for rich Markdown styling

## Testing
- `npm test --silent`
- `npm run lint --silent`
- `npm run type-check --silent`


------
https://chatgpt.com/codex/tasks/task_e_6870538e9f208325b5311e8ab7eb2c35