### PR TITLE
Fix pdf.js worker imports

### DIFF
--- a/app/tools/pdf-compressor/pdf-compressor-client.tsx
+++ b/app/tools/pdf-compressor/pdf-compressor-client.tsx
@@ -39,7 +39,7 @@ export default function PdfCompressorClient() {
     try {
       const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf");
       const worker = (
-        await import("pdfjs-dist/legacy/build/pdf.worker.entry?url")
+        await import("pdfjs-dist/legacy/build/pdf.worker.mjs?url")
       ).default;
       pdfjsLib.GlobalWorkerOptions.workerSrc = worker;
 

--- a/app/tools/pdf-to-word/pdf-to-word-client.tsx
+++ b/app/tools/pdf-to-word/pdf-to-word-client.tsx
@@ -41,7 +41,7 @@ export default function PdfToWordClient() {
     try {
       const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf");
       const worker = (
-        await import("pdfjs-dist/legacy/build/pdf.worker.entry?worker&url")
+        await import("pdfjs-dist/legacy/build/pdf.worker.mjs?worker&url")
       ).default;
       pdfjsLib.GlobalWorkerOptions.workerSrc = worker;
 
@@ -81,7 +81,7 @@ export default function PdfToWordClient() {
       try {
         const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf");
         const worker = (
-          await import("pdfjs-dist/legacy/build/pdf.worker.entry?worker&url")
+          await import("pdfjs-dist/legacy/build/pdf.worker.mjs?worker&url")
         ).default;
         pdfjsLib.GlobalWorkerOptions.workerSrc = worker;
         const arrayBuffer = await readFileAsArrayBuffer(file);

--- a/types/pdfjs-dist.d.ts
+++ b/types/pdfjs-dist.d.ts
@@ -93,6 +93,6 @@ declare module "pdfjs-dist/legacy/build/pdf" {
 }
 
 /** The companion worker entrypoint. */
-declare module "pdfjs-dist/legacy/build/pdf.worker.entry";
-declare module "pdfjs-dist/legacy/build/pdf.worker.entry?url";
-declare module "pdfjs-dist/legacy/build/pdf.worker.entry?worker&url";
+declare module "pdfjs-dist/legacy/build/pdf.worker.mjs";
+declare module "pdfjs-dist/legacy/build/pdf.worker.mjs?url";
+declare module "pdfjs-dist/legacy/build/pdf.worker.mjs?worker&url";


### PR DESCRIPTION
## Summary
- fix PDF worker imports for pdf.js tools

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_687053ad85a88325aac1895e59811059