### PR TITLE
Add hash and YAML/JSON converter tools

### DIFF
--- a/app/tools/password-generator/password-generator-client.tsx
+++ b/app/tools/password-generator/password-generator-client.tsx
@@ -3,8 +3,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, ChangeEvent } from "react";
-import { generatePassword } from "../../../../lib/generate-password";
-
+import { generatePassword } from "@/lib/generate-password";
 
 export default function PasswordGeneratorClient() {
   const [length, setLength] = useState(16);
@@ -166,7 +165,6 @@ export default function PasswordGeneratorClient() {
             </label>
           </div>
         </fieldset>
-
       </form>
     </section>
   );

--- a/app/tools/sha-hash-generator/page.tsx
+++ b/app/tools/sha-hash-generator/page.tsx
@@ -1,0 +1,59 @@
+import ShaHashGeneratorClient from "./sha-hash-generator-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "Hash Generator | Gearizen",
+  description:
+    "Create SHA-256, SHA-1, or MD5 hashes instantly with Gearizen's client-side Hash Generator. Private, fast, and free.",
+  keywords: [
+    "hash generator",
+    "sha256",
+    "sha1",
+    "md5",
+    "online hash tool",
+    "client-side hash",
+    "Gearizen hash",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/sha-hash-generator" },
+  openGraph: {
+    title: "Hash Generator | Gearizen",
+    description:
+      "Generate SHA and MD5 hashes in your browser with Gearizen's Hash Generator. 100% client-side, no signup.",
+    url: "https://gearizen.com/tools/sha-hash-generator",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen Hash Generator",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Hash Generator | Gearizen",
+    description:
+      "Use Gearizen's client-side Hash Generator to create SHA or MD5 hashes instantly—privacy guaranteed.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function ShaHashGeneratorPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Hash Generator"
+        pageUrl="https://gearizen.com/tools/sha-hash-generator"
+      />
+      <ShaHashGeneratorClient />
+    </>
+  );
+}

--- a/app/tools/sha-hash-generator/sha-hash-generator-client.tsx
+++ b/app/tools/sha-hash-generator/sha-hash-generator-client.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+
+async function computeHash(
+  text: string,
+  algorithm: "SHA-256" | "SHA-1" | "MD5",
+) {
+  if (algorithm === "MD5") {
+    const { default: SparkMD5 } = await import("spark-md5");
+    return SparkMD5.hash(text);
+  }
+  const encoder = new TextEncoder();
+  const data = encoder.encode(text);
+  const buf = await crypto.subtle.digest(algorithm, data);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export default function ShaHashGeneratorClient() {
+  const [input, setInput] = useState("");
+  const [algorithm, setAlgorithm] = useState<"SHA-256" | "SHA-1" | "MD5">(
+    "SHA-256",
+  );
+  const [hash, setHash] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const generate = async () => {
+    setError(null);
+    setHash("");
+    try {
+      const result = await computeHash(input, algorithm);
+      setHash(result);
+    } catch {
+      setError("Hash generation failed.");
+    }
+  };
+
+  const copyHash = async () => {
+    if (!hash) return;
+    try {
+      await navigator.clipboard.writeText(hash);
+      alert("✅ Hash copied to clipboard!");
+    } catch {
+      alert("❌ Failed to copy hash.");
+    }
+  };
+
+  return (
+    <section
+      id="sha-hash-generator"
+      aria-labelledby="sha-hash-generator-heading"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="sha-hash-generator-heading"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        Hash Generator
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Generate SHA-256, SHA-1 or MD5 hashes directly in your browser. 100%
+        client-side and private.
+      </p>
+
+      <div className="max-w-xl mx-auto space-y-6">
+        <div>
+          <label
+            htmlFor="hash-input"
+            className="block mb-1 font-medium text-gray-800"
+          >
+            Input Text
+          </label>
+          <textarea
+            id="hash-input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            rows={4}
+            className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="algorithm"
+            className="block mb-1 font-medium text-gray-800"
+          >
+            Algorithm
+          </label>
+          <select
+            id="algorithm"
+            value={algorithm}
+            onChange={(e) =>
+              setAlgorithm(e.target.value as "SHA-256" | "SHA-1" | "MD5")
+            }
+            className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="SHA-256">SHA-256</option>
+            <option value="SHA-1">SHA-1</option>
+            <option value="MD5">MD5</option>
+          </select>
+        </div>
+
+        <button
+          type="button"
+          onClick={generate}
+          className="w-full py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
+        >
+          Generate Hash
+        </button>
+
+        {hash && (
+          <div className="space-y-4">
+            <label
+              htmlFor="hash-output"
+              className="block mb-1 font-medium text-gray-800"
+            >
+              Generated Hash
+            </label>
+            <textarea
+              id="hash-output"
+              readOnly
+              value={hash}
+              rows={4}
+              className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            />
+            <div className="flex justify-end gap-4">
+              <button
+                onClick={copyHash}
+                className="px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 transition text-sm font-medium"
+              >
+                Copy Hash
+              </button>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <p role="alert" className="text-red-600 text-sm">
+            {error}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -33,6 +33,8 @@ import {
   AlignLeft,
   Type,
   Link as LinkIcon,
+  Hash,
+  Braces,
 } from "lucide-react";
 
 interface Tool {
@@ -73,7 +75,8 @@ const tools: Tool[] = [
     href: "/tools/image-compressor",
     Icon: ImageIcon,
     title: "Image Compressor",
-    description: "Reduce JPEG or PNG file sizes while preserving visual quality.",
+    description:
+      "Reduce JPEG or PNG file sizes while preserving visual quality.",
   },
   {
     href: "/tools/color-contrast-checker",
@@ -224,6 +227,18 @@ const tools: Tool[] = [
     title: "URL Encoder/Decoder",
     description: "Encode or decode URLs and query strings.",
   },
+  {
+    href: "/tools/sha-hash-generator",
+    Icon: Hash,
+    title: "Hash Generator",
+    description: "Create SHA-256, SHA-1 or MD5 hashes for any text.",
+  },
+  {
+    href: "/tools/yaml-json-converter",
+    Icon: Braces,
+    title: "YAML ⇄ JSON Converter",
+    description: "Convert YAML to JSON or JSON to YAML in-browser.",
+  },
 ];
 
 export default function ToolsClient() {
@@ -240,61 +255,61 @@ export default function ToolsClient() {
       aria-labelledby="all-tools-heading"
       className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900 space-y-12"
     >
-        {/* Hero */}
-        <header className="text-center max-w-3xl mx-auto space-y-4">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight">
-            Free Online Tools
-          </h1>
-          <p className="text-lg sm:text-xl text-gray-700 leading-relaxed">
-            Gearizen offers 100% client-side utilities—generators, converters,
-            compressors, formatters, validators, and more—all free and no signup
-            required.
-          </p>
-        </header>
+      {/* Hero */}
+      <header className="text-center max-w-3xl mx-auto space-y-4">
+        <h1 className="text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight">
+          Free Online Tools
+        </h1>
+        <p className="text-lg sm:text-xl text-gray-700 leading-relaxed">
+          Gearizen offers 100% client-side utilities—generators, converters,
+          compressors, formatters, validators, and more—all free and no signup
+          required.
+        </p>
+      </header>
 
-        {/* Search */}
-        <div className="max-w-md mx-auto">
-          <label htmlFor="tool-search" className="sr-only">
-            Search tools
-          </label>
-          <input
-            id="tool-search"
-            type="search"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search tools..."
-            className="w-full border border-gray-300 rounded-lg px-4 py-2 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
-        </div>
+      {/* Search */}
+      <div className="max-w-md mx-auto">
+        <label htmlFor="tool-search" className="sr-only">
+          Search tools
+        </label>
+        <input
+          id="tool-search"
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search tools..."
+          className="w-full border border-gray-300 rounded-lg px-4 py-2 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+      </div>
 
-        {/* Grid */}
-        <section aria-labelledby="tools-heading">
-          <h2 id="tools-heading" className="sr-only">
-            All Tools
-          </h2>
-          <ul className="grid gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-            {filteredTools.map(({ href, Icon, title, description }) => (
-              <li key={href} className="list-none">
-                <Link
-                  href={href}
-                  aria-label={`Navigate to ${title}`}
-                  className="group flex flex-col h-full bg-white border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
-                >
-                  <Icon
-                    className="w-10 h-10 text-indigo-600 mx-auto mb-4"
-                    aria-hidden="true"
-                  />
-                  <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-indigo-600 transition-colors">
-                    {title}
-                  </h3>
-                  <p className="text-gray-600 text-center flex-grow">
-                    {description}
-                  </p>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </section>
+      {/* Grid */}
+      <section aria-labelledby="tools-heading">
+        <h2 id="tools-heading" className="sr-only">
+          All Tools
+        </h2>
+        <ul className="grid gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {filteredTools.map(({ href, Icon, title, description }) => (
+            <li key={href} className="list-none">
+              <Link
+                href={href}
+                aria-label={`Navigate to ${title}`}
+                className="group flex flex-col h-full bg-white border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
+              >
+                <Icon
+                  className="w-10 h-10 text-indigo-600 mx-auto mb-4"
+                  aria-hidden="true"
+                />
+                <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-indigo-600 transition-colors">
+                  {title}
+                </h3>
+                <p className="text-gray-600 text-center flex-grow">
+                  {description}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
     </section>
   );
 }

--- a/app/tools/yaml-json-converter/page.tsx
+++ b/app/tools/yaml-json-converter/page.tsx
@@ -1,0 +1,58 @@
+import YamlJsonConverterClient from "./yaml-json-converter-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "YAML ⇄ JSON Converter | Gearizen",
+  description:
+    "Easily convert YAML to JSON or JSON to YAML with Gearizen's client-side converter. Private and fast.",
+  keywords: [
+    "yaml to json",
+    "json to yaml",
+    "yaml converter",
+    "json converter",
+    "client-side yaml tool",
+    "Gearizen yaml json",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/yaml-json-converter" },
+  openGraph: {
+    title: "YAML ⇄ JSON Converter | Gearizen",
+    description:
+      "Convert YAML and JSON files right in your browser using Gearizen's privacy-focused converter—no uploads required.",
+    url: "https://gearizen.com/tools/yaml-json-converter",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen YAML JSON Converter",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "YAML ⇄ JSON Converter | Gearizen",
+    description:
+      "Use Gearizen's client-side converter to turn YAML into JSON or JSON into YAML effortlessly.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function YamlJsonConverterPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="YAML ⇄ JSON Converter"
+        pageUrl="https://gearizen.com/tools/yaml-json-converter"
+      />
+      <YamlJsonConverterClient />
+    </>
+  );
+}

--- a/app/tools/yaml-json-converter/yaml-json-converter-client.tsx
+++ b/app/tools/yaml-json-converter/yaml-json-converter-client.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState, ChangeEvent, useEffect } from "react";
+import useDebounce from "@/lib/useDebounce";
+
+type Mode = "yaml2json" | "json2yaml";
+
+export default function YamlJsonConverterClient() {
+  const [yamlInput, setYamlInput] = useState("");
+  const [jsonInput, setJsonInput] = useState("");
+  const [mode, setMode] = useState<Mode>("yaml2json");
+  const [error, setError] = useState<string | null>(null);
+  const debouncedYaml = useDebounce(yamlInput);
+  const debouncedJson = useDebounce(jsonInput);
+
+  useEffect(() => {
+    if (mode === "yaml2json" && debouncedYaml.trim()) {
+      convertYamlToJson(debouncedYaml);
+    } else if (mode === "json2yaml" && debouncedJson.trim()) {
+      convertJsonToYaml(debouncedJson);
+    } else {
+      if (mode === "yaml2json") setJsonInput("");
+      else setYamlInput("");
+    }
+  }, [debouncedYaml, debouncedJson, mode]);
+
+  async function convertYamlToJson(src: string) {
+    try {
+      const yaml = await import("js-yaml");
+      const obj = yaml.load(src);
+      setJsonInput(JSON.stringify(obj, null, 2));
+      setError(null);
+    } catch {
+      setError("Invalid YAML input.");
+      setJsonInput("");
+    }
+  }
+
+  async function convertJsonToYaml(src: string) {
+    try {
+      const yaml = await import("js-yaml");
+      const obj = JSON.parse(src);
+      setYamlInput(yaml.dump(obj));
+      setError(null);
+    } catch {
+      setError("Invalid JSON input.");
+      setYamlInput("");
+    }
+  }
+
+  const handleYamlChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setYamlInput(e.target.value);
+    setError(null);
+  };
+
+  const handleJsonChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setJsonInput(e.target.value);
+    setError(null);
+  };
+
+  const copyYaml = async () => {
+    if (!yamlInput) return;
+    try {
+      await navigator.clipboard.writeText(yamlInput);
+      alert("✅ YAML copied to clipboard!");
+    } catch {
+      alert("❌ Failed to copy YAML.");
+    }
+  };
+
+  const copyJson = async () => {
+    if (!jsonInput) return;
+    try {
+      await navigator.clipboard.writeText(jsonInput);
+      alert("✅ JSON copied to clipboard!");
+    } catch {
+      alert("❌ Failed to copy JSON.");
+    }
+  };
+
+  return (
+    <section
+      id="yaml-json-converter"
+      aria-labelledby="yaml-json-converter-heading"
+      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="yaml-json-converter-heading"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        YAML ⇄ JSON Converter
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Convert YAML to JSON or JSON to YAML entirely in your browser—no data
+        ever leaves your device.
+      </p>
+
+      <div
+        className="max-w-4xl mx-auto space-y-6"
+        aria-label="YAML JSON converter form"
+      >
+        <div className="flex justify-center gap-4">
+          <label className="flex items-center space-x-2">
+            <input
+              type="radio"
+              checked={mode === "yaml2json"}
+              onChange={() => setMode("yaml2json")}
+            />
+            <span className="text-sm">YAML → JSON</span>
+          </label>
+          <label className="flex items-center space-x-2">
+            <input
+              type="radio"
+              checked={mode === "json2yaml"}
+              onChange={() => setMode("json2yaml")}
+            />
+            <span className="text-sm">JSON → YAML</span>
+          </label>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <div>
+            <label
+              htmlFor="yaml-input"
+              className="block mb-1 font-medium text-gray-800"
+            >
+              YAML
+            </label>
+            <textarea
+              id="yaml-input"
+              value={yamlInput}
+              onChange={handleYamlChange}
+              placeholder="key: value"
+              rows={10}
+              className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            />
+            <button
+              type="button"
+              onClick={copyYaml}
+              disabled={!yamlInput}
+              className="mt-2 px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition text-sm font-medium disabled:opacity-60"
+            >
+              Copy YAML
+            </button>
+          </div>
+
+          <div>
+            <label
+              htmlFor="json-input"
+              className="block mb-1 font-medium text-gray-800"
+            >
+              JSON
+            </label>
+            <textarea
+              id="json-input"
+              value={jsonInput}
+              onChange={handleJsonChange}
+              placeholder={`{\n  "key": "value"\n}`}
+              rows={10}
+              className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            />
+            <button
+              type="button"
+              onClick={copyJson}
+              disabled={!jsonInput}
+              className="mt-2 px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition text-sm font-medium disabled:opacity-60"
+            >
+              Copy JSON
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <p role="alert" className="text-red-600 text-sm">
+            {error}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "html2pdf.js": "^0.10.3",
         "isomorphic-dompurify": "^2.26.0",
         "js-beautify": "^1.15.4",
+        "js-yaml": "^4.1.0",
         "json5": "^2.2.3",
         "jsonlint-mod": "^1.7.6",
         "lucide-react": "^0.525.0",
@@ -27,7 +28,8 @@
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-icons": "^5.5.0"
+        "react-icons": "^5.5.0",
+        "spark-md5": "^3.0.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.41.2",
@@ -37,6 +39,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/jest": "^30.0.0",
         "@types/js-beautify": "^1.14.3",
+        "@types/js-yaml": "^4.0.9",
         "@types/marked": "^5.0.2",
         "@types/node": "^20.19.4",
         "@types/papaparse": "^5.3.16",
@@ -44,6 +47,7 @@
         "@types/qrcode": "^1.5.5",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/spark-md5": "^3.0.5",
         "eslint": "^9.8.0",
         "eslint-config-next": "15.3.5",
         "husky": "^8.0.0",
@@ -3002,6 +3006,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3089,6 +3100,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/spark-md5": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.5.tgz",
+      "integrity": "sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -3803,7 +3821,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -8162,7 +8179,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10742,6 +10758,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "spark-md5": "^3.0.2",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.2",
@@ -51,6 +53,8 @@
     "@types/qrcode": "^1.5.5",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/spark-md5": "^3.0.5",
+    "@types/js-yaml": "^4.0.9",
     "eslint": "^9.8.0",
     "eslint-config-next": "15.3.5",
     "husky": "^8.0.0",


### PR DESCRIPTION
## Summary
- add a hash generator tool supporting SHA-256, SHA-1 and MD5
- add a YAML ⇄ JSON converter tool
- register new tools in the tools directory
- update password generator import path
- include new dependencies for hashing and YAML parsing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687056bf11f083259ad636a0f0bd7673