### PR TITLE
Refine styles with new Tailwind palette

### DIFF
--- a/app/about/about-client.tsx
+++ b/app/about/about-client.tsx
@@ -9,7 +9,7 @@ export default function AboutClient() {
     <section
       id="about-gearizen"
       aria-labelledby="about-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       {/* Heading */}
       <h1
@@ -49,7 +49,7 @@ export default function AboutClient() {
         We value your feedback and suggestions. To get in touch, please visit our{" "}
         <Link
           href="/contact"
-          className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+          className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
           aria-label="Go to Contact page"
         >
           Contact page

--- a/app/contact/contact-client.tsx
+++ b/app/contact/contact-client.tsx
@@ -7,7 +7,7 @@ export default function ContactClient() {
     <section
       id="contact-gearizen"
       aria-labelledby="contact-heading"
-      className="container-responsive py-16 text-gray-900"
+      className="container-responsive py-20 text-gray-900"
     >
       <h1
         id="contact-heading"
@@ -17,7 +17,7 @@ export default function ContactClient() {
       </h1>
       <p className="text-lg text-gray-700 mb-12 max-w-xl mx-auto text-center">
         Have questions or feedback? Please email us at
-        <a href="mailto:gearizen.tahir.ozcan@gmail.com" className="text-indigo-600 underline ml-1">
+        <a href="mailto:gearizen.tahir.ozcan@gmail.com" className="text-brand-600 underline ml-1">
           gearizen.tahir.ozcan@gmail.com
         </a>
         .

--- a/app/cookies/cookies-client.tsx
+++ b/app/cookies/cookies-client.tsx
@@ -9,7 +9,7 @@ export default function CookiesClient() {
     <section
       id="cookie-policy"
       aria-labelledby="cookie-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       {/* Başlık */}
       <h1
@@ -64,7 +64,7 @@ export default function CookiesClient() {
               href="https://adssettings.google.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
             >
               Google Ads Settings
             </a>
@@ -91,7 +91,7 @@ export default function CookiesClient() {
             If you have any questions about our cookie policy, please{" "}
             <Link
               href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
             >
               contact us
             </Link>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -8,7 +8,7 @@ export default function GlobalError({ reset }: { reset: () => void }) {
         <h1 className="text-4xl font-bold mb-4">Something went wrong</h1>
         <p className="mb-6">An unexpected error occurred. Please try again or return home.</p>
         <div className="space-x-4">
-          <button onClick={reset} className="px-4 py-2 rounded bg-indigo-600 text-white">Try Again</button>
+          <button onClick={reset} className="px-4 py-2 rounded bg-brand-600 text-white">Try Again</button>
           <Link href="/" className="px-4 py-2 rounded bg-gray-200 text-gray-900">Home</Link>
         </div>
       </body>

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,15 +13,15 @@
 
 @layer components {
   .btn-primary {
-    @apply px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium;
+    @apply px-6 py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium;
   }
   .btn-secondary {
     @apply px-6 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition font-medium;
   }
   .input-base {
-    @apply w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition;
+    @apply w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 transition;
   }
   .container-responsive {
-    @apply container mx-auto px-6 sm:px-8 md:px-10 lg:px-16;
+    @apply container mx-auto px-4 sm:px-6 md:px-8 lg:px-12;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,13 +5,13 @@ import { ReactNode } from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import AnalyticsLoader from "./components/AnalyticsLoader";
-import { Inter, Poppins } from "next/font/google";
+import { Inter, Montserrat } from "next/font/google";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
-const poppins = Poppins({
+const montserrat = Montserrat({
   subsets: ["latin"],
   weight: ["400", "600", "700"],
-  variable: "--font-poppins",
+  variable: "--font-montserrat",
   display: "swap",
 });
 
@@ -79,7 +79,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${poppins.variable} bg-white text-gray-900 antialiased scroll-smooth`}
+      className={`${inter.variable} ${montserrat.variable} bg-white text-gray-900 antialiased scroll-smooth`}
       suppressHydrationWarning
     >
       <head>
@@ -102,7 +102,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           {/* Accessible skip link */}
           <a
             href="#main-content"
-            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md z-50"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-brand-600 text-white rounded-md z-50"
           >
             Skip to main content
           </a>
@@ -116,7 +116,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           role="main"
           tabIndex={-1}
           aria-label="Main content"
-          className="flex-grow container-responsive py-10"
+          className="flex-grow container-responsive py-12"
         >
           {children}
         </main>

--- a/app/not-found/not-found-client.tsx
+++ b/app/not-found/not-found-client.tsx
@@ -16,13 +16,13 @@ export default function NotFoundClient() {
     <section
       id="notfound-section"
       aria-labelledby="notfound-title"
-      className="container-responsive py-20 flex flex-col items-center justify-center min-h-screen text-center text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 flex flex-col items-center justify-center min-h-screen text-center text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="notfound-title"
         tabIndex={-1}
         aria-label="404 - Page Not Found"
-        className="text-7xl sm:text-8xl font-extrabold text-indigo-600 mb-4 tracking-tight"
+        className="text-7xl sm:text-8xl font-extrabold text-brand-600 mb-4 tracking-tight"
       >
         404
       </h1>
@@ -37,7 +37,7 @@ export default function NotFoundClient() {
       <Link
         href="/"
         aria-label="Return to Gearizen homepage"
-        className="inline-block bg-indigo-600 text-white font-semibold rounded-md px-6 py-3 hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition"
+        className="inline-block bg-brand-600 text-white font-semibold rounded-md px-6 py-3 hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 transition"
       >
         Go to Homepage
       </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,19 +59,19 @@ const websiteJsonLd = {
 const popularTools = [
   {
     href: "/tools/password-generator",
-    icon: <Key aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
+    icon: <Key aria-hidden="true" className="w-10 h-10 text-brand-600" />,
     title: "Password Generator",
     description: "Generate strong, customizable passwords instantly.",
   },
   {
     href: "/tools/pdf-to-word",
-    icon: <FilePlus aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
+    icon: <FilePlus aria-hidden="true" className="w-10 h-10 text-brand-600" />,
     title: "PDF → Word Converter",
     description: "Convert PDFs to editable Word documents quickly.",
   },
   {
     href: "/tools/qr-code-generator",
-    icon: <QrCode aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
+    icon: <QrCode aria-hidden="true" className="w-10 h-10 text-brand-600" />,
     title: "QR Code Generator",
     description: "Create QR codes for URLs, text, contacts, and more.",
   },
@@ -80,7 +80,7 @@ const popularTools = [
     icon: (
       <ArrowRightLeft
         aria-hidden="true"
-        className="w-10 h-10 text-indigo-600"
+        className="w-10 h-10 text-brand-600"
       />
     ),
     title: "Unit Converter",
@@ -89,7 +89,7 @@ const popularTools = [
   {
     href: "/tools/image-compressor",
     icon: (
-      <ImageIcon aria-hidden="true" className="w-10 h-10 text-indigo-600" />
+      <ImageIcon aria-hidden="true" className="w-10 h-10 text-brand-600" />
     ),
     title: "Image Compressor",
     description: "Reduce image file sizes while preserving quality.",
@@ -98,12 +98,12 @@ const popularTools = [
 
 export default function HomePage() {
   return (
-    <div className="bg-white text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900">
+    <div className="bg-white text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900">
       <JsonLd data={websiteJsonLd} />
       {/* Hero */}
       <section
         aria-labelledby="hero-heading"
-        className="container-responsive pt-16 pb-12 text-center"
+        className="container-responsive pt-20 pb-16 text-center"
       >
         <h1
           id="hero-heading"
@@ -117,7 +117,7 @@ export default function HomePage() {
         </p>
         <Link
           href="/tools"
-          className="mt-8 inline-block bg-indigo-600 text-white font-semibold rounded-full px-8 py-3 shadow-md hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition-colors"
+          className="mt-8 inline-block bg-brand-600 text-white font-semibold rounded-full px-8 py-3 shadow-md hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 transition-colors"
         >
           Discover All Tools
         </Link>
@@ -126,7 +126,7 @@ export default function HomePage() {
       {/* Popular Tools */}
       <section
         aria-labelledby="tools-heading"
-        className="container-responsive pb-16"
+        className="container-responsive pb-20"
       >
         <h2
           id="tools-heading"
@@ -141,12 +141,12 @@ export default function HomePage() {
               <Link
                 href={href}
                 aria-label={`Navigate to ${title}`}
-                className="group flex flex-col h-full bg-white border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
+                className="group flex flex-col h-full bg-white border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-colors"
               >
                 <div className="mb-6 flex items-center justify-center">
                   {icon}
                 </div>
-                <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-indigo-600 transition-colors">
+                <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-brand-600 transition-colors">
                   {title}
                 </h3>
                 <p className="text-gray-600 flex-grow text-center">
@@ -161,7 +161,7 @@ export default function HomePage() {
             <Link
               href="/contact"
               aria-label="Suggest a tool to the Gearizen team"
-              className="group flex flex-col items-center justify-center bg-white border border-dashed border-gray-300 rounded-2xl p-6 shadow-sm hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors text-center"
+              className="group flex flex-col items-center justify-center bg-white border border-dashed border-gray-300 rounded-2xl p-6 shadow-sm hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-colors text-center"
             >
               <HelpCircle
                 aria-hidden="true"

--- a/app/privacy/privacy-client.tsx
+++ b/app/privacy/privacy-client.tsx
@@ -9,7 +9,7 @@ export default function PrivacyClient() {
     <section
       id="privacy-policy"
       aria-labelledby="privacy-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="privacy-heading"
@@ -97,7 +97,7 @@ export default function PrivacyClient() {
             If you have questions about this policy, please{" "}
             <Link
               href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
               aria-label="Go to Contact page"
             >
               get in touch

--- a/app/terms/terms-client.tsx
+++ b/app/terms/terms-client.tsx
@@ -9,7 +9,7 @@ export default function TermsClient() {
     <section
       id="terms-of-use"
       aria-labelledby="terms-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="terms-heading"
@@ -23,7 +23,7 @@ export default function TermsClient() {
         “Service”), you agree to these Terms of Use and our{" "}
         <Link
           href="/privacy"
-          className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+          className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
         >
           Privacy Policy
         </Link>
@@ -118,7 +118,7 @@ export default function TermsClient() {
             If you have any questions about these terms, please{" "}
             <Link
               href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
             >
               get in touch
             </Link>

--- a/app/tools/base64-encoder-decoder/base64-encoder-decoder-client.tsx
+++ b/app/tools/base64-encoder-decoder/base64-encoder-decoder-client.tsx
@@ -52,7 +52,7 @@ export default function Base64EncoderDecoderClient() {
     <section
       id="base64-encoder-decoder"
       aria-labelledby="base64-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="base64-heading"
@@ -73,7 +73,7 @@ export default function Base64EncoderDecoderClient() {
         value={input}
         onChange={handleInput}
         placeholder="Enter text or Base64..."
-        className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+        className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
       />
 
       {/* Controls */}
@@ -81,14 +81,14 @@ export default function Base64EncoderDecoderClient() {
         <button
           type="button"
           onClick={encode}
-          className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
         >
           Encode
         </button>
         <button
           type="button"
           onClick={decode}
-          className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
         >
           Decode
         </button>
@@ -119,7 +119,7 @@ export default function Base64EncoderDecoderClient() {
           readOnly
           value={output}
           aria-label="Base64 result"
-          className="mt-6 w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          className="mt-6 w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
         />
       )}
     </section>

--- a/app/tools/bcrypt-generator/bcrypt-generator-client.tsx
+++ b/app/tools/bcrypt-generator/bcrypt-generator-client.tsx
@@ -47,7 +47,7 @@ export default function BcryptGeneratorClient() {
     <section
       id="bcrypt-generator"
       aria-labelledby="bcrypt-generator-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="bcrypt-generator-heading"
@@ -72,7 +72,7 @@ export default function BcryptGeneratorClient() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Enter password to hash"
-            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         </div>
 
@@ -104,7 +104,7 @@ export default function BcryptGeneratorClient() {
         <button
           onClick={generateHash}
           disabled={loading}
-          className={`w-full py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium ${
+          className={`w-full py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium ${
             loading ? "opacity-60 cursor-not-allowed" : ""
           }`}
         >
@@ -122,7 +122,7 @@ export default function BcryptGeneratorClient() {
               readOnly
               value={hash}
               rows={4}
-              className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition resize-y"
+              className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 transition resize-y"
             />
             <div className="flex justify-end gap-4">
               <button

--- a/app/tools/code-minifier/code-minifier-client.tsx
+++ b/app/tools/code-minifier/code-minifier-client.tsx
@@ -60,7 +60,7 @@ export default function CodeMinifierClient() {
     <section
       id="code-minifier"
       aria-labelledby="code-minifier-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="code-minifier-heading"
@@ -80,7 +80,7 @@ export default function CodeMinifierClient() {
         value={input}
         onChange={handleInput}
         placeholder="Paste your code here..."
-        className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+        className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
       />
 
       {/* Controls */}
@@ -88,7 +88,7 @@ export default function CodeMinifierClient() {
         <button
           type="button"
           onClick={minifyCode}
-          className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
         >
           Minify
         </button>
@@ -127,7 +127,7 @@ export default function CodeMinifierClient() {
           aria-label="Minified code output"
           value={output}
           readOnly
-          className="mt-6 w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          className="mt-6 w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
         />
       )}
     </section>

--- a/app/tools/color-contrast-checker/color-contrast-checker-client.tsx
+++ b/app/tools/color-contrast-checker/color-contrast-checker-client.tsx
@@ -67,7 +67,7 @@ export default function ColorContrastCheckerClient() {
     <section
       id="color-contrast-checker"
       aria-labelledby="contrast-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="contrast-heading"
@@ -120,7 +120,7 @@ export default function ColorContrastCheckerClient() {
       <div className="max-w-md mx-auto space-y-4 mb-10">
         <p className="text-center text-xl font-semibold">
           Contrast Ratio:{" "}
-          <span className="text-indigo-600">{contrastRatio}:1</span>
+          <span className="text-brand-600">{contrastRatio}:1</span>
         </p>
         <ul className="space-y-1 text-gray-700">
           <li>
@@ -170,7 +170,7 @@ export default function ColorContrastCheckerClient() {
       <div className="text-center">
         <button
           onClick={copyCss}
-          className="px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          className="px-6 py-3 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
         >
           Copy CSS Snippet
         </button>

--- a/app/tools/csv-to-json/csv-to-json-client.tsx
+++ b/app/tools/csv-to-json/csv-to-json-client.tsx
@@ -69,7 +69,7 @@ export default function CsvToJsonClient() {
     <section
       id="csv-to-json"
       aria-labelledby="csv-to-json-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="csv-to-json-heading"
@@ -93,7 +93,7 @@ export default function CsvToJsonClient() {
             onChange={handleCsvChange}
             placeholder="column1,column2,column3\nvalue1,value2,value3\n…"
             rows={8}
-            className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         </div>
 
@@ -115,7 +115,7 @@ export default function CsvToJsonClient() {
             readOnly
             value={jsonText}
             rows={10}
-            className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
           <div className="flex justify-center gap-4">
             <button

--- a/app/tools/html-formatter/html-formatter-client.tsx
+++ b/app/tools/html-formatter/html-formatter-client.tsx
@@ -56,7 +56,7 @@ export default function HtmlFormatterClient() {
     <section
       id="html-formatter"
       aria-labelledby="html-formatter-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="html-formatter-heading"
@@ -78,7 +78,7 @@ export default function HtmlFormatterClient() {
         onChange={handleInputChange}
         placeholder="<div>Hello&nbsp;World</div>"
         rows={10}
-        className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+        className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
       />
 
       <div className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
@@ -90,7 +90,7 @@ export default function HtmlFormatterClient() {
               value={indentSize}
               onChange={e => setIndentSize(Number(e.target.value))}
               disabled={minify}
-              className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+              className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 transition"
             >
               <option value={0}>0</option>
               <option value={2}>2</option>
@@ -105,7 +105,7 @@ export default function HtmlFormatterClient() {
               type="checkbox"
               checked={minify}
               onChange={() => setMinify(!minify)}
-              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+              className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
             />
             <span className="text-sm text-gray-700">Minify</span>
           </label>
@@ -115,7 +115,7 @@ export default function HtmlFormatterClient() {
           <button
             type="button"
             onClick={runFormat}
-            className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+            className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
           >
             Format / Minify
           </button>
@@ -158,7 +158,7 @@ export default function HtmlFormatterClient() {
             value={output}
             readOnly
             rows={10}
-            className="mt-6 w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="mt-6 w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         </>
       )}

--- a/app/tools/html-to-pdf/html-to-pdf-client.tsx
+++ b/app/tools/html-to-pdf/html-to-pdf-client.tsx
@@ -51,7 +51,7 @@ export default function HtmlToPdfClient() {
     <section
       id="html-to-pdf"
       aria-labelledby="html-to-pdf-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="html-to-pdf-heading"
@@ -73,7 +73,7 @@ export default function HtmlToPdfClient() {
         onChange={handleInputChange}
         placeholder="<h1>Hello, world!</h1>"
         rows={10}
-        className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+        className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
       />
 
       {error && (
@@ -87,7 +87,7 @@ export default function HtmlToPdfClient() {
           type="button"
           onClick={generatePdf}
           disabled={processing}
-          className={`px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium ${
+          className={`px-6 py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium ${
             processing ? "opacity-60 cursor-not-allowed" : ""
           }`}
         >

--- a/app/tools/image-compressor/image-compressor-client.tsx
+++ b/app/tools/image-compressor/image-compressor-client.tsx
@@ -110,7 +110,7 @@ export default function ImageCompressorClient() {
     <section
       id="image-compressor"
       aria-labelledby="image-compressor-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="image-compressor-heading"
@@ -128,7 +128,7 @@ export default function ImageCompressorClient() {
           type="file"
           accept="image/*"
           onChange={handleFileChange}
-          className="file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-indigo-600 file:text-white hover:file:bg-indigo-700 focus-visible:ring-2 focus-visible:ring-indigo-500"
+          className="file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-brand-600 file:text-white hover:file:bg-brand-700 focus-visible:ring-2 focus-visible:ring-brand-500"
         />
       </div>
 

--- a/app/tools/image-resizer/image-resizer-client.tsx
+++ b/app/tools/image-resizer/image-resizer-client.tsx
@@ -104,7 +104,7 @@ export default function ImageResizerClient() {
     <section
       id="image-resizer"
       aria-labelledby="image-resizer-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="image-resizer-heading"
@@ -180,7 +180,7 @@ export default function ImageResizerClient() {
               value={width}
               onChange={e => setWidth(Number(e.target.value))}
               className="w-24 p-2 border border-gray-300 rounded-lg
-                         focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+                         focus:outline-none focus:ring-1 focus:ring-brand-500 transition"
             />
           </div>
           <div className="flex items-center justify-between">
@@ -195,7 +195,7 @@ export default function ImageResizerClient() {
               onChange={e => setHeight(Number(e.target.value))}
               disabled={maintainAspect}
               className="w-24 p-2 border border-gray-300 rounded-lg
-                         focus:outline-none focus:ring-1 focus:ring-indigo-500 transition disabled:opacity-50"
+                         focus:outline-none focus:ring-1 focus:ring-brand-500 transition disabled:opacity-50"
             />
           </div>
           <div className="flex items-center space-x-2">
@@ -204,7 +204,7 @@ export default function ImageResizerClient() {
               type="checkbox"
               checked={maintainAspect}
               onChange={() => setMaintainAspect(a => !a)}
-              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+              className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
             />
             <label htmlFor="maintain-aspect" className="text-gray-700">
               Maintain aspect ratio

--- a/app/tools/image-to-base64/image-to-base64-client.tsx
+++ b/app/tools/image-to-base64/image-to-base64-client.tsx
@@ -33,19 +33,19 @@ export default function ImageToBase64Client() {
         type="file"
         accept="image/*"
         onChange={handleFile}
-        className="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:bg-indigo-600 file:text-white hover:file:bg-indigo-700"
+        className="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:bg-brand-600 file:text-white hover:file:bg-brand-700"
       />
       {result && (
         <div className="space-y-4">
           <textarea
             readOnly
             value={result}
-            className="w-full h-40 p-3 border border-gray-300 rounded-lg font-mono text-xs bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full h-40 p-3 border border-gray-300 rounded-lg font-mono text-xs bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
           <button
             type="button"
             onClick={copy}
-            className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             Copy
           </button>

--- a/app/tools/iso-date-converter/iso-date-converter-client.tsx
+++ b/app/tools/iso-date-converter/iso-date-converter-client.tsx
@@ -41,7 +41,7 @@ export default function IsoDateConverterClient() {
             type="datetime-local"
             value={iso.split(".")[0]}
             onChange={handleIsoChange}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </label>
         <label className="block">
@@ -50,7 +50,7 @@ export default function IsoDateConverterClient() {
             type="text"
             value={timestamp}
             onChange={handleTimestampChange}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </label>
       </div>

--- a/app/tools/json-formatter/json-formatter-client.tsx
+++ b/app/tools/json-formatter/json-formatter-client.tsx
@@ -87,7 +87,7 @@ export default function JsonFormatterClient() {
     <section
       id="json-formatter"
       aria-labelledby="json-formatter-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="json-formatter-heading"
@@ -106,7 +106,7 @@ export default function JsonFormatterClient() {
           value={input}
           onChange={handleInputChange}
           placeholder="Paste or type your JSON here..."
-          className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
         />
 
         {/* Options & Actions */}
@@ -119,7 +119,7 @@ export default function JsonFormatterClient() {
                 disabled={mode === 'minify'}
                 value={indent}
                 onChange={(e) => setIndent(Number(e.target.value))}
-                className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+                className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-brand-500 transition"
               >
                 <option value={0}>0</option>
                 <option value={2}>2</option>
@@ -135,7 +135,7 @@ export default function JsonFormatterClient() {
                 value="beautify"
                 checked={mode === 'beautify'}
                 onChange={() => setMode('beautify')}
-                className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 focus:ring-brand-500"
               />
               <span className="text-sm text-gray-700">Beautify</span>
             </label>
@@ -146,7 +146,7 @@ export default function JsonFormatterClient() {
                 value="minify"
                 checked={mode === 'minify'}
                 onChange={() => setMode('minify')}
-                className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 focus:ring-brand-500"
               />
               <span className="text-sm text-gray-700">Minify</span>
             </label>
@@ -157,7 +157,7 @@ export default function JsonFormatterClient() {
                 value="validate"
                 checked={mode === 'validate'}
                 onChange={() => setMode('validate')}
-                className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 focus:ring-brand-500"
               />
               <span className="text-sm text-gray-700">Validate</span>
             </label>
@@ -167,7 +167,7 @@ export default function JsonFormatterClient() {
                 type="checkbox"
                 checked={sortKeys}
                 onChange={() => setSortKeys((s) => !s)}
-                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
               />
               <span className="text-sm text-gray-700">Sort keys</span>
             </label>
@@ -177,7 +177,7 @@ export default function JsonFormatterClient() {
                 type="checkbox"
                 checked={!strict}
                 onChange={() => setStrict((v) => !v)}
-                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
               />
               <span className="text-sm text-gray-700">Lenient JSON5</span>
             </label>
@@ -219,7 +219,7 @@ export default function JsonFormatterClient() {
             readOnly
             aria-label="Formatted JSON output"
             value={output}
-            className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full h-48 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         )}
       </div>

--- a/app/tools/jwt-decoder/jwt-decoder-client.tsx
+++ b/app/tools/jwt-decoder/jwt-decoder-client.tsx
@@ -59,7 +59,7 @@ export default function JwtDecoderClient() {
     <section
       id="jwt-decoder"
       aria-labelledby="jwt-decoder-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="jwt-decoder-heading"
@@ -80,13 +80,13 @@ export default function JwtDecoderClient() {
         value={token}
         onChange={handleChange}
         placeholder="Paste your JWT here..."
-        className="w-full h-32 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+        className="w-full h-32 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
       />
 
       <div className="mt-4 text-center">
         <button
           onClick={decodeJwt}
-          className="inline-block px-6 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          className="inline-block px-6 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
         >
           Decode Token
         </button>
@@ -111,7 +111,7 @@ export default function JwtDecoderClient() {
               </h2>
               <button
                 onClick={() => copyJson(parts.header, "Header JSON")}
-                className="text-indigo-600 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded transition text-sm"
+                className="text-brand-600 hover:underline focus:outline-none focus:ring-2 focus:ring-brand-500 rounded transition text-sm"
               >
                 Copy
               </button>
@@ -129,7 +129,7 @@ export default function JwtDecoderClient() {
               </h2>
               <button
                 onClick={() => copyJson(parts.payload, "Payload JSON")}
-                className="text-indigo-600 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded transition text-sm"
+                className="text-brand-600 hover:underline focus:outline-none focus:ring-2 focus:ring-brand-500 rounded transition text-sm"
               >
                 Copy
               </button>
@@ -152,7 +152,7 @@ export default function JwtDecoderClient() {
                     () => alert("❌ Copy failed.")
                   )
                 }
-                className="text-indigo-600 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded transition text-sm"
+                className="text-brand-600 hover:underline focus:outline-none focus:ring-2 focus:ring-brand-500 rounded transition text-sm"
               >
                 Copy
               </button>

--- a/app/tools/lorem-ipsum-generator/lorem-ipsum-generator-client.tsx
+++ b/app/tools/lorem-ipsum-generator/lorem-ipsum-generator-client.tsx
@@ -47,7 +47,7 @@ export default function LoremIpsumGeneratorClient() {
           <select
             value={mode}
             onChange={handleMode}
-            className="w-full border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="paragraphs">Paragraphs</option>
             <option value="sentences">Sentences</option>
@@ -57,7 +57,7 @@ export default function LoremIpsumGeneratorClient() {
         <button
           type="button"
           onClick={handleGenerate}
-          className="flex-1 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          className="flex-1 px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           Generate
         </button>
@@ -65,12 +65,12 @@ export default function LoremIpsumGeneratorClient() {
       <textarea
         readOnly
         value={output}
-        className="w-full h-40 p-3 border border-gray-300 rounded-lg bg-gray-50 resize-y font-mono text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        className="w-full h-40 p-3 border border-gray-300 rounded-lg bg-gray-50 resize-y font-mono text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
       />
       <button
         type="button"
         onClick={copy}
-        className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500"
       >
         Copy
       </button>

--- a/app/tools/markdown-to-html/markdown-to-html-client.tsx
+++ b/app/tools/markdown-to-html/markdown-to-html-client.tsx
@@ -53,7 +53,7 @@ export default function MarkdownToHtmlClient() {
     <section
       id="markdown-to-html"
       aria-labelledby="markdown-to-html-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="markdown-to-html-heading"
@@ -77,7 +77,7 @@ export default function MarkdownToHtmlClient() {
             value={markdown}
             onChange={handleMarkdownChange}
             placeholder="Enter Markdown here..."
-            className="w-full h-64 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full h-64 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         </div>
 
@@ -91,7 +91,7 @@ export default function MarkdownToHtmlClient() {
             value={html}
             readOnly
             placeholder="Converted HTML will appear here..."
-            className="w-full h-64 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full h-64 p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         </div>
       </div>
@@ -101,7 +101,7 @@ export default function MarkdownToHtmlClient() {
         <button
           type="button"
           onClick={convert}
-          className="px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          className="px-6 py-3 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
         >
           Convert
         </button>

--- a/app/tools/password-generator/password-generator-client.tsx
+++ b/app/tools/password-generator/password-generator-client.tsx
@@ -50,7 +50,7 @@ export default function PasswordGeneratorClient() {
     <section
       id="password-generator"
       aria-labelledby="password-generator-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="password-generator-heading"
@@ -78,13 +78,13 @@ export default function PasswordGeneratorClient() {
             readOnly
             value={password}
             aria-label="Generated password"
-            className="flex-grow bg-white border border-gray-300 rounded-lg px-4 py-2 font-mono text-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="flex-grow bg-white border border-gray-300 rounded-lg px-4 py-2 font-mono text-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
           <button
             type="button"
             onClick={copyPassword}
             aria-label="Copy password to clipboard"
-            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
+            className="px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium"
           >
             {copied ? "Copied!" : "Copy"}
           </button>
@@ -133,7 +133,7 @@ export default function PasswordGeneratorClient() {
                 type="checkbox"
                 checked={useUpper}
                 onChange={() => setUseUpper((u) => !u)}
-                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
               />
               <span className="text-gray-700 select-none">Uppercase (A–Z)</span>
             </label>
@@ -142,7 +142,7 @@ export default function PasswordGeneratorClient() {
                 type="checkbox"
                 checked={useLower}
                 onChange={() => setUseLower((u) => !u)}
-                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
               />
               <span className="text-gray-700 select-none">Lowercase (a–z)</span>
             </label>
@@ -151,7 +151,7 @@ export default function PasswordGeneratorClient() {
                 type="checkbox"
                 checked={useDigits}
                 onChange={() => setUseDigits((d) => !d)}
-                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
               />
               <span className="text-gray-700 select-none">Numbers (0–9)</span>
             </label>
@@ -160,7 +160,7 @@ export default function PasswordGeneratorClient() {
                 type="checkbox"
                 checked={useSymbols}
                 onChange={() => setUseSymbols((s) => !s)}
-                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
               />
               <span className="text-gray-700 select-none">Symbols (!@#$…)</span>
             </label>

--- a/app/tools/pdf-compressor/pdf-compressor-client.tsx
+++ b/app/tools/pdf-compressor/pdf-compressor-client.tsx
@@ -116,7 +116,7 @@ export default function PdfCompressorClient() {
     <section
       id="pdf-compressor"
       aria-labelledby="pdf-compressor-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="pdf-compressor-heading"
@@ -176,7 +176,7 @@ export default function PdfCompressorClient() {
         <button
           onClick={compressPdf}
           disabled={!file || isCompressing}
-          className={`inline-flex items-center px-8 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium disabled:opacity-60 ${
+          className={`inline-flex items-center px-8 py-3 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium disabled:opacity-60 ${
             isCompressing ? "cursor-not-allowed" : ""
           }`}
         >

--- a/app/tools/pdf-to-word/pdf-to-word-client.tsx
+++ b/app/tools/pdf-to-word/pdf-to-word-client.tsx
@@ -114,7 +114,7 @@ export default function PdfToWordClient() {
     <section
       id="pdf-to-word"
       aria-labelledby="pdf-to-word-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="pdf-to-word-heading"
@@ -149,7 +149,7 @@ export default function PdfToWordClient() {
         <button
           onClick={convertPdf}
           disabled={!file || processing}
-          className={`inline-flex items-center px-8 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium ${
+          className={`inline-flex items-center px-8 py-3 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium ${
             processing ? "opacity-60 cursor-not-allowed" : ""
           }`}
         >

--- a/app/tools/qr-code-generator/qr-code-generator-client.tsx
+++ b/app/tools/qr-code-generator/qr-code-generator-client.tsx
@@ -58,7 +58,7 @@ export default function QrCodeGeneratorClient() {
     <section
       id="qr-code-generator"
       aria-labelledby="qr-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="qr-heading"
@@ -84,7 +84,7 @@ export default function QrCodeGeneratorClient() {
             value={text}
             onChange={(e) => setText(e.target.value)}
             placeholder="Enter text or link..."
-            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         </div>
 

--- a/app/tools/regex-tester/regex-tester-client.tsx
+++ b/app/tools/regex-tester/regex-tester-client.tsx
@@ -63,7 +63,7 @@ export default function RegexTesterClient() {
     <section
       id="regex-tester"
       aria-labelledby="regex-tester-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="regex-tester-heading"
@@ -88,7 +88,7 @@ export default function RegexTesterClient() {
               value={pattern}
               onChange={handlePatternChange}
               placeholder="e.g. \\b\\w+\\b"
-              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
             />
           </div>
           <div>
@@ -101,7 +101,7 @@ export default function RegexTesterClient() {
               value={flags}
               onChange={handleFlagsChange}
               placeholder="e.g. gmi"
-              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
             />
           </div>
         </div>
@@ -116,7 +116,7 @@ export default function RegexTesterClient() {
             value={testInput}
             onChange={handleInputChange}
             placeholder="Paste or type text to test..."
-            className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
         </div>
 

--- a/app/tools/seo-meta-tag-generator/seo-meta-tag-generator-client.tsx
+++ b/app/tools/seo-meta-tag-generator/seo-meta-tag-generator-client.tsx
@@ -58,7 +58,7 @@ export default function SeoMetaTagGeneratorClient() {
     <section
       id="seo-meta-tag-generator"
       aria-labelledby="seo-meta-tag-generator-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="seo-meta-tag-generator-heading"
@@ -82,7 +82,7 @@ export default function SeoMetaTagGeneratorClient() {
             value={title}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
             placeholder="Enter your page title"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand-500 transition"
           />
         </div>
 
@@ -97,7 +97,7 @@ export default function SeoMetaTagGeneratorClient() {
             value={description}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setDescription(e.target.value)}
             placeholder="Enter a concise page description"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-indigo-500 transition resize-y"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand-500 transition resize-y"
           />
         </div>
 
@@ -112,7 +112,7 @@ export default function SeoMetaTagGeneratorClient() {
             value={keywords}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setKeywords(e.target.value)}
             placeholder="keyword1, keyword2"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand-500 transition"
           />
         </div>
 
@@ -127,7 +127,7 @@ export default function SeoMetaTagGeneratorClient() {
             value={url}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setUrl(e.target.value)}
             placeholder="https://gearizen.com/your-page"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand-500 transition"
           />
         </div>
 
@@ -142,7 +142,7 @@ export default function SeoMetaTagGeneratorClient() {
             value={image}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setImage(e.target.value)}
             placeholder="https://gearizen.com/og-placeholder.svg"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand-500 transition"
           />
         </div>
 
@@ -157,7 +157,7 @@ export default function SeoMetaTagGeneratorClient() {
                 value="summary_large_image"
                 checked={twitterCard === "summary_large_image"}
                 onChange={() => setTwitterCard("summary_large_image")}
-                className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 focus:ring-brand-500"
               />
               <span className="text-gray-700">Large Image</span>
             </label>
@@ -168,7 +168,7 @@ export default function SeoMetaTagGeneratorClient() {
                 value="summary"
                 checked={twitterCard === "summary"}
                 onChange={() => setTwitterCard("summary")}
-                className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+                className="h-4 w-4 text-brand-600 border-gray-300 focus:ring-brand-500"
               />
               <span className="text-gray-700">Text Only</span>
             </label>
@@ -180,7 +180,7 @@ export default function SeoMetaTagGeneratorClient() {
           <button
             onClick={handleCopy}
             disabled={!title && !description && !url && !image && !keywords}
-            className="inline-flex items-center px-8 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium disabled:opacity-60"
+            className="inline-flex items-center px-8 py-3 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium disabled:opacity-60"
           >
             Copy Meta Tags
           </button>
@@ -195,7 +195,7 @@ export default function SeoMetaTagGeneratorClient() {
           readOnly
           value={generateMetaTags()}
           rows={10}
-          className="w-full font-mono text-sm p-4 bg-gray-50 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          className="w-full font-mono text-sm p-4 bg-gray-50 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
         />
       </div>
     </section>

--- a/app/tools/text-counter/text-counter-client.tsx
+++ b/app/tools/text-counter/text-counter-client.tsx
@@ -14,7 +14,7 @@ export default function TextCounterClient() {
     <section
       id="text-counter"
       aria-labelledby="text-counter-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="text-counter-heading"
@@ -30,14 +30,14 @@ export default function TextCounterClient() {
         onChange={(e) => setText(e.target.value)}
         rows={8}
         placeholder="Enter your text..."
-        className="w-full max-w-3xl mx-auto block border border-gray-300 rounded-lg p-4 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition resize-y"
+        className="w-full max-w-3xl mx-auto block border border-gray-300 rounded-lg p-4 focus:outline-none focus:ring-2 focus:ring-brand-500 transition resize-y"
       />
       <label className="mt-4 flex items-center justify-center gap-2 text-sm">
         <input
           type="checkbox"
           checked={ignoreSpaces}
           onChange={() => setIgnoreSpaces(!ignoreSpaces)}
-          className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+          className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
         />
         Ignore spaces in character count
       </label>

--- a/app/tools/text-diff/text-diff-client.tsx
+++ b/app/tools/text-diff/text-diff-client.tsx
@@ -48,7 +48,7 @@ export default function TextDiffClient() {
     <section
       id="text-diff"
       aria-labelledby="text-diff-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="text-diff-heading"
@@ -72,7 +72,7 @@ export default function TextDiffClient() {
               value={original}
               onChange={handleOriginalChange}
               placeholder="Enter original text..."
-              className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+              className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
             />
           </div>
           <div>
@@ -84,7 +84,7 @@ export default function TextDiffClient() {
               value={modified}
               onChange={handleModifiedChange}
               placeholder="Enter modified text..."
-              className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+              className="w-full h-40 p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
             />
           </div>
         </div>
@@ -92,7 +92,7 @@ export default function TextDiffClient() {
         <div className="text-center">
           <button
             type="submit"
-            className="px-8 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
+            className="px-8 py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium"
           >
             Compare
           </button>

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -238,7 +238,7 @@ export default function ToolsClient() {
     <section
       id="all-tools"
       aria-labelledby="all-tools-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900 space-y-12"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900 space-y-12"
     >
         {/* Hero */}
         <header className="text-center max-w-3xl mx-auto space-y-4">
@@ -263,7 +263,7 @@ export default function ToolsClient() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search tools..."
-            className="w-full border border-gray-300 rounded-lg px-4 py-2 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full border border-gray-300 rounded-lg px-4 py-2 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
         </div>
 
@@ -278,13 +278,13 @@ export default function ToolsClient() {
                 <Link
                   href={href}
                   aria-label={`Navigate to ${title}`}
-                  className="group flex flex-col h-full bg-white border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
+                  className="group flex flex-col h-full bg-white border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-colors"
                 >
                   <Icon
-                    className="w-10 h-10 text-indigo-600 mx-auto mb-4"
+                    className="w-10 h-10 text-brand-600 mx-auto mb-4"
                     aria-hidden="true"
                   />
-                  <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-indigo-600 transition-colors">
+                  <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-brand-600 transition-colors">
                     {title}
                   </h3>
                   <p className="text-gray-600 text-center flex-grow">

--- a/app/tools/unit-converter/unit-converter-client.tsx
+++ b/app/tools/unit-converter/unit-converter-client.tsx
@@ -152,7 +152,7 @@ export default function UnitConverterClient() {
     <section
       id="unit-converter"
       aria-labelledby="unit-converter-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="unit-converter-heading"
@@ -178,7 +178,7 @@ export default function UnitConverterClient() {
             id="category"
             value={category}
             onChange={onCategoryChange}
-            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           >
             {Object.entries(categories).map(([key, { label }]) => (
               <option key={key} value={key}>
@@ -197,7 +197,7 @@ export default function UnitConverterClient() {
               id="from-unit"
               value={fromUnit}
               onChange={e => setFromUnit(e.target.value)}
-              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
             >
               {Object.entries(categories[category].units).map(([value, label]) => (
                 <option key={value} value={value}>
@@ -214,7 +214,7 @@ export default function UnitConverterClient() {
               id="to-unit"
               value={toUnit}
               onChange={e => setToUnit(e.target.value)}
-              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+              className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
             >
               {Object.entries(categories[category].units).map(([value, label]) => (
                 <option key={value} value={value}>
@@ -228,7 +228,7 @@ export default function UnitConverterClient() {
         <button
           type="button"
           onClick={swapUnits}
-          className="block mx-auto text-indigo-600 hover:underline focus:outline-none transition"
+          className="block mx-auto text-brand-600 hover:underline focus:outline-none transition"
         >
           Swap units
         </button>
@@ -243,7 +243,7 @@ export default function UnitConverterClient() {
             value={input}
             onChange={e => setInput(e.target.value)}
             placeholder="Enter value"
-            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-mono"
+            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-mono"
           />
         </div>
 
@@ -258,7 +258,7 @@ export default function UnitConverterClient() {
         <div className="mt-12 max-w-lg mx-auto text-center">
           <p className="text-xl">
             Result:{" "}
-            <span className="font-mono text-xl text-indigo-600">
+            <span className="font-mono text-xl text-brand-600">
               {output}
             </span>{" "}
             {categories[category].units[toUnit]}

--- a/app/tools/unix-timestamp-converter/unix-timestamp-converter-client.tsx
+++ b/app/tools/unix-timestamp-converter/unix-timestamp-converter-client.tsx
@@ -70,7 +70,7 @@ export default function UnixTimestampConverterClient() {
     <section
       id="unix-timestamp-converter"
       aria-labelledby="utc-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="utc-heading"
@@ -96,7 +96,7 @@ export default function UnixTimestampConverterClient() {
             value={timestampInput}
             onChange={handleTimestampChange}
             placeholder="e.g. 1657286400 or 1657286400000"
-            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-mono"
+            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-mono"
           />
           {tsError && (
             <p role="alert" className="text-red-600 text-sm">
@@ -105,7 +105,7 @@ export default function UnixTimestampConverterClient() {
           )}
           <button
             type="submit"
-            className="w-full py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
+            className="w-full py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium"
           >
             Convert to Date
           </button>
@@ -133,7 +133,7 @@ export default function UnixTimestampConverterClient() {
             value={dateInput}
             onChange={handleDateChange}
             placeholder="e.g. 2023-07-08T00:00:00Z"
-            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 transition"
           />
           {dateError && (
             <p role="alert" className="text-red-600 text-sm">
@@ -142,7 +142,7 @@ export default function UnixTimestampConverterClient() {
           )}
           <button
             type="submit"
-            className="w-full py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
+            className="w-full py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium"
           >
             Convert to Timestamp
           </button>

--- a/app/tools/url-encoder-decoder/url-encoder-decoder-client.tsx
+++ b/app/tools/url-encoder-decoder/url-encoder-decoder-client.tsx
@@ -37,13 +37,13 @@ export default function UrlEncoderDecoderClient() {
         value={input}
         onChange={handleInput}
         placeholder="Enter text or URL..."
-        className="w-full h-32 p-3 border border-gray-300 rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        className="w-full h-32 p-3 border border-gray-300 rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-brand-500"
       />
       <div className="flex flex-wrap gap-4">
-        <button onClick={encode} className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <button onClick={encode} className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500">
           Encode
         </button>
-        <button onClick={decode} className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <button onClick={decode} className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500">
           Decode
         </button>
         <button onClick={copy} disabled={!output} className="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 disabled:opacity-60">
@@ -54,7 +54,7 @@ export default function UrlEncoderDecoderClient() {
         readOnly
         value={output}
         placeholder="Result will appear here..."
-        className="w-full h-32 p-3 border border-gray-300 rounded-lg bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        className="w-full h-32 p-3 border border-gray-300 rounded-lg bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-brand-500"
       />
     </section>
   );

--- a/app/tools/uuid-generator/page-client.tsx
+++ b/app/tools/uuid-generator/page-client.tsx
@@ -66,7 +66,7 @@ export default function UuidGeneratorClient() {
     <section
       id="uuid-generator"
       aria-labelledby="uuid-generator-heading"
-      className="container-responsive py-16 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="uuid-generator-heading"
@@ -105,7 +105,7 @@ export default function UuidGeneratorClient() {
               type="checkbox"
               checked={uppercase}
               onChange={() => setUppercase((v) => !v)}
-              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+              className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
             />
             <span className="text-sm text-gray-700">Uppercase</span>
           </label>
@@ -145,7 +145,7 @@ export default function UuidGeneratorClient() {
         <div className="flex flex-wrap gap-3">
           <button
             type="submit"
-            className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+            className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition text-sm font-medium"
           >
             Generate
           </button>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -96,7 +96,7 @@ export default function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={label}
-                  className="text-gray-500 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                  className="text-gray-500 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                 >
                   {icon}
                 </a>
@@ -117,7 +117,7 @@ export default function Footer() {
                 <li key={href} className="list-none">
                   <Link
                     href={href}
-                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                   >
                     {label}
                   </Link>
@@ -139,7 +139,7 @@ export default function Footer() {
                 <li key={href} className="list-none">
                   <Link
                     href={href}
-                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                   >
                     {label}
                   </Link>
@@ -158,7 +158,7 @@ export default function Footer() {
                     href={href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                   >
                     {label}
                   </a>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -50,7 +50,7 @@ export default function Navbar() {
       {/* Skip link */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-brand-600 text-white rounded-md"
       >
         Skip to main content
       </a>
@@ -87,10 +87,10 @@ export default function Navbar() {
                 aria-current={active ? "page" : undefined}
                 className={`
                   relative text-sm font-medium transition-colors
-                  focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2
+                  focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2
                   ${
                     active
-                      ? "text-indigo-600 after:absolute after:-bottom-1 after:left-0 after:w-full after:h-0.5 after:bg-indigo-600"
+                      ? "text-brand-600 after:absolute after:-bottom-1 after:left-0 after:w-full after:h-0.5 after:bg-brand-600"
                       : "text-gray-700 hover:text-gray-900"
                   }
                 `}
@@ -108,7 +108,7 @@ export default function Navbar() {
           aria-label={isOpen ? "Close menu" : "Open menu"}
           aria-expanded={isOpen}
           aria-controls="mobile-menu"
-          className="md:hidden p-2 rounded-md text-gray-800 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition"
+          className="md:hidden p-2 rounded-md text-gray-800 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 transition"
         >
           {isOpen ? (
             <X className="w-6 h-6" aria-hidden="true" />
@@ -139,10 +139,10 @@ export default function Navbar() {
                     aria-current={active ? "page" : undefined}
                     className={`
                       block w-full px-4 py-2 text-base font-medium rounded-md transition-colors
-                      focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2
                       ${
                         active
-                          ? "bg-indigo-50 text-indigo-600"
+                          ? "bg-brand-50 text-brand-600"
                           : "text-gray-700 hover:bg-gray-100 hover:text-gray-900"
                       }
                     `}

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,7 +1,7 @@
 "use client";
 export default function Spinner({ className = "" }: { className?: string }) {
   return (
-    <div className={`animate-spin rounded-full h-8 w-8 border-4 border-indigo-500 border-t-transparent ${className}`} role="status" aria-label="Loading" />
+    <div className={`animate-spin rounded-full h-8 w-8 border-4 border-brand-500 border-t-transparent ${className}`} role="status" aria-label="Loading" />
   );
 }
 

--- a/components/ToolProviders.tsx
+++ b/components/ToolProviders.tsx
@@ -13,7 +13,7 @@ export default function ToolProviders({ children }: { children: ReactNode }) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="fixed bottom-4 right-4 z-50 px-3 py-2 bg-indigo-600 text-white rounded-full shadow-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        className="fixed bottom-4 right-4 z-50 px-3 py-2 bg-brand-600 text-white rounded-full shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-500"
         aria-label="Toggle tool settings"
       >
         ⚙️

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -20,24 +20,25 @@ export default {
     extend: {
       fontFamily: {
         sans: ["var(--font-inter)", ...defaultTheme.fontFamily.sans],
-        display: ["var(--font-poppins)", ...defaultTheme.fontFamily.sans],
+        display: ["var(--font-montserrat)", ...defaultTheme.fontFamily.sans],
       },
       colors: {
-        indigo: {
-          50: "#f0f4ff",
+        brand: {
+          50: "#eef2ff",
           100: "#e0e7ff",
-          200: "#c7d1ff",
-          300: "#a3b0ff",
-          400: "#8a97ff",
-          500: "#6b7cff",
-          600: "#4f5fd4",
-          700: "#3947a5",
-          800: "#2d3778",
-          900: "#1e244d",
+          200: "#c7d2fe",
+          300: "#a5b4fc",
+          400: "#818cf8",
+          500: "#6366f1",
+          600: "#4f46e5",
+          700: "#4338ca",
+          800: "#3730a3",
+          900: "#312e81",
         },
       },
       spacing: {
         18: "4.5rem",
+        22: "5.5rem",
       },
     },
   },


### PR DESCRIPTION
## Summary
- update Tailwind to use `brand` palette and Montserrat display font
- tweak global classes for primary buttons, inputs and container padding
- adjust layout spacing and skip link color
- swap to Montserrat in layout
- update every page/client component to use the new `brand` color and larger spacing

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687057a38af08325952f8e54b9739000