### PR TITLE
Fix path for password generator module

### DIFF
--- a/app/tools/password-generator/password-generator-client.tsx
+++ b/app/tools/password-generator/password-generator-client.tsx
@@ -3,7 +3,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, ChangeEvent } from "react";
-import { generatePassword } from "../../../../lib/generate-password";
+// Correct relative path to the shared password utility
+import { generatePassword } from "../../../lib/generate-password";
 
 
 export default function PasswordGeneratorClient() {


### PR DESCRIPTION
## Summary
- correct path to `generate-password` module

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6870585000e88325ae00a23c1b2a985d