### PR TITLE
Fix Tailwind config and restore styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,19 +7,19 @@
   h4,
   h5,
   h6 {
-    @apply font-display;
+    font-family: theme('fontFamily.sans');
   }
 }
 
 @layer components {
   .btn-primary {
-    @apply px-6 py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium;
+    @apply px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium;
   }
   .btn-secondary {
     @apply px-6 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition font-medium;
   }
   .input-base {
-    @apply w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 transition;
+    @apply w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition;
   }
   .container-responsive {
     @apply container mx-auto px-4 sm:px-6 md:px-8 lg:px-12;

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@types/spark-md5": "^3.0.5",
+        "autoprefixer": "^10.4.21",
         "eslint": "^9.8.0",
         "eslint-config-next": "15.3.5",
         "husky": "^8.0.0",
@@ -4046,6 +4047,44 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -6156,6 +6195,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/framer-motion": {
@@ -9386,6 +9439,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -9999,6 +10062,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "html2pdf.js": "^0.10.3",
     "isomorphic-dompurify": "^2.26.0",
     "js-beautify": "^1.15.4",
+    "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
     "jsonlint-mod": "^1.7.6",
     "lucide-react": "^0.525.0",
@@ -35,8 +36,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
-    "spark-md5": "^3.0.2",
-    "js-yaml": "^4.1.0"
+    "spark-md5": "^3.0.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.41.2",
@@ -47,6 +47,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/jest": "^30.0.0",
     "@types/js-beautify": "^1.14.3",
+    "@types/js-yaml": "^4.0.9",
     "@types/marked": "^5.0.2",
     "@types/node": "^20.19.4",
     "@types/papaparse": "^5.3.16",
@@ -55,7 +56,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/spark-md5": "^3.0.5",
-    "@types/js-yaml": "^4.0.9",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.8.0",
     "eslint-config-next": "15.3.5",
     "husky": "^8.0.0",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['@tailwindcss/postcss', 'autoprefixer'],
 };
 
 export default config;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [require('@tailwindcss/typography')],
-};

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,20 +1,17 @@
-import defaultTheme from "tailwindcss/defaultTheme.js";
+import defaultTheme from 'tailwindcss/defaultTheme.js'
+import typography from '@tailwindcss/typography'
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    "./app/**/*.{ts,tsx}",
-    "./components/**/*.{ts,tsx}",
-    "./lib/**/*.{ts,tsx}",
-  ],
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './lib/**/*.{ts,tsx}'],
   theme: {
     container: {
       center: true,
       padding: {
-        DEFAULT: "1.5rem",
-        sm: "2rem",
-        md: "2.5rem",
-        lg: "4rem",
+        DEFAULT: '1.5rem',
+        sm: '2rem',
+        md: '2.5rem',
+        lg: '4rem',
       },
     },
     extend: {
@@ -22,25 +19,11 @@ export default {
         sans: [...defaultTheme.fontFamily.sans],
         display: [...defaultTheme.fontFamily.sans],
       },
-      colors: {
-        brand: {
-          50: "#eef2ff",
-          100: "#e0e7ff",
-          200: "#c7d2fe",
-          300: "#a5b4fc",
-          400: "#818cf8",
-          500: "#6366f1",
-          600: "#4f46e5",
-          700: "#4338ca",
-          800: "#3730a3",
-          900: "#312e81",
-        },
-      },
       spacing: {
-        18: "4.5rem",
-        22: "5.5rem",
+        18: '4.5rem',
+        22: '5.5rem',
       },
     },
   },
-  plugins: [],
-};
+  plugins: [typography],
+}


### PR DESCRIPTION
## Summary
- repair `globals.css` utilities so compilation succeeds
- switch PostCSS setup to include autoprefixer
- simplify Tailwind config using built‑in Indigo palette and typography plugin
- add autoprefixer dev dependency

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68705e3bd9448325ba0f08647cf558ce