### PR TITLE
Improve design with branded colors and fonts

### DIFF
--- a/app/about/about-client.tsx
+++ b/app/about/about-client.tsx
@@ -9,7 +9,7 @@ export default function AboutClient() {
     <section
       id="about-gearizen"
       aria-labelledby="about-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       {/* Heading */}
       <h1
@@ -49,7 +49,7 @@ export default function AboutClient() {
         We value your feedback and suggestions. To get in touch, please visit our{" "}
         <Link
           href="/contact"
-          className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+          className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
           aria-label="Go to Contact page"
         >
           Contact page

--- a/app/contact/contact-client.tsx
+++ b/app/contact/contact-client.tsx
@@ -17,7 +17,7 @@ export default function ContactClient() {
       </h1>
       <p className="text-lg text-gray-700 mb-12 max-w-xl mx-auto text-center">
         Have questions or feedback? Please email us at
-        <a href="mailto:gearizen.tahir.ozcan@gmail.com" className="text-indigo-600 underline ml-1">
+        <a href="mailto:gearizen.tahir.ozcan@gmail.com" className="text-brand-600 underline ml-1">
           gearizen.tahir.ozcan@gmail.com
         </a>
         .

--- a/app/cookies/cookies-client.tsx
+++ b/app/cookies/cookies-client.tsx
@@ -9,7 +9,7 @@ export default function CookiesClient() {
     <section
       id="cookie-policy"
       aria-labelledby="cookie-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       {/* Başlık */}
       <h1
@@ -64,7 +64,7 @@ export default function CookiesClient() {
               href="https://adssettings.google.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
             >
               Google Ads Settings
             </a>
@@ -91,7 +91,7 @@ export default function CookiesClient() {
             If you have any questions about our cookie policy, please{" "}
             <Link
               href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
             >
               contact us
             </Link>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -8,7 +8,7 @@ export default function GlobalError({ reset }: { reset: () => void }) {
         <h1 className="text-4xl font-bold mb-4">Something went wrong</h1>
         <p className="mb-6">An unexpected error occurred. Please try again or return home.</p>
         <div className="space-x-4">
-          <button onClick={reset} className="px-4 py-2 rounded bg-indigo-600 text-white">Try Again</button>
+          <button onClick={reset} className="px-4 py-2 rounded bg-brand-600 text-white">Try Again</button>
           <Link href="/" className="px-4 py-2 rounded bg-gray-200 text-gray-900">Home</Link>
         </div>
       </body>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,12 @@
 @import "tailwindcss";
+@import "@fontsource/inter/400.css";
+@import "@fontsource/inter/600.css";
+@import "@fontsource/inter/700.css";
 
 @layer base {
+  body {
+    font-family: theme('fontFamily.sans');
+  }
   h1,
   h2,
   h3,
@@ -13,13 +19,13 @@
 
 @layer components {
   .btn-primary {
-    @apply px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium;
+    @apply px-6 py-3 bg-brand-600 text-white rounded-lg hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 transition font-medium;
   }
   .btn-secondary {
-    @apply px-6 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition font-medium;
+    @apply px-6 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-brand-700 transition font-medium;
   }
   .input-base {
-    @apply w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition;
+    @apply w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 transition;
   }
   .container-responsive {
     @apply container mx-auto px-4 sm:px-6 md:px-8 lg:px-12;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -90,7 +90,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           {/* Accessible skip link */}
           <a
             href="#main-content"
-            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md z-50"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-brand-600 text-white rounded-md z-50"
           >
             Skip to main content
           </a>

--- a/app/not-found/not-found-client.tsx
+++ b/app/not-found/not-found-client.tsx
@@ -16,13 +16,13 @@ export default function NotFoundClient() {
     <section
       id="notfound-section"
       aria-labelledby="notfound-title"
-      className="container-responsive py-20 flex flex-col items-center justify-center min-h-screen text-center text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 flex flex-col items-center justify-center min-h-screen text-center text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="notfound-title"
         tabIndex={-1}
         aria-label="404 - Page Not Found"
-        className="text-7xl sm:text-8xl font-extrabold text-indigo-600 mb-4 tracking-tight"
+        className="text-7xl sm:text-8xl font-extrabold text-brand-600 mb-4 tracking-tight"
       >
         404
       </h1>
@@ -37,7 +37,7 @@ export default function NotFoundClient() {
       <Link
         href="/"
         aria-label="Return to Gearizen homepage"
-        className="inline-block bg-indigo-600 text-white font-semibold rounded-md px-6 py-3 hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition"
+        className="inline-block bg-brand-600 text-white font-semibold rounded-md px-6 py-3 hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 transition"
       >
         Go to Homepage
       </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,19 +59,19 @@ const websiteJsonLd = {
 const popularTools = [
   {
     href: "/tools/password-generator",
-    icon: <Key aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
+    icon: <Key aria-hidden="true" className="w-10 h-10 text-brand-600" />,
     title: "Password Generator",
     description: "Generate strong, customizable passwords instantly.",
   },
   {
     href: "/tools/pdf-to-word",
-    icon: <FilePlus aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
+    icon: <FilePlus aria-hidden="true" className="w-10 h-10 text-brand-600" />,
     title: "PDF → Word Converter",
     description: "Convert PDFs to editable Word documents quickly.",
   },
   {
     href: "/tools/qr-code-generator",
-    icon: <QrCode aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
+    icon: <QrCode aria-hidden="true" className="w-10 h-10 text-brand-600" />,
     title: "QR Code Generator",
     description: "Create QR codes for URLs, text, contacts, and more.",
   },
@@ -80,7 +80,7 @@ const popularTools = [
     icon: (
       <ArrowRightLeft
         aria-hidden="true"
-        className="w-10 h-10 text-indigo-600"
+        className="w-10 h-10 text-brand-600"
       />
     ),
     title: "Unit Converter",
@@ -89,7 +89,7 @@ const popularTools = [
   {
     href: "/tools/image-compressor",
     icon: (
-      <ImageIcon aria-hidden="true" className="w-10 h-10 text-indigo-600" />
+      <ImageIcon aria-hidden="true" className="w-10 h-10 text-brand-600" />
     ),
     title: "Image Compressor",
     description: "Reduce image file sizes while preserving quality.",
@@ -98,7 +98,7 @@ const popularTools = [
 
 export default function HomePage() {
   return (
-    <div className="bg-white text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900">
+    <div className="bg-white text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900">
       <JsonLd data={websiteJsonLd} />
       {/* Hero */}
       <section
@@ -117,7 +117,7 @@ export default function HomePage() {
         </p>
         <Link
           href="/tools"
-          className="mt-8 inline-block bg-indigo-600 text-white font-semibold rounded-full px-8 py-3 shadow-md hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition-colors"
+          className="mt-8 inline-block bg-brand-600 text-white font-semibold rounded-full px-8 py-3 shadow-md hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 transition-colors"
         >
           Discover All Tools
         </Link>
@@ -146,7 +146,7 @@ export default function HomePage() {
                 <div className="mb-6 flex items-center justify-center">
                   {icon}
                 </div>
-                <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-indigo-600 transition-colors">
+                <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-brand-600 transition-colors">
                   {title}
                 </h3>
                 <p className="text-gray-600 flex-grow text-center">

--- a/app/privacy/privacy-client.tsx
+++ b/app/privacy/privacy-client.tsx
@@ -9,7 +9,7 @@ export default function PrivacyClient() {
     <section
       id="privacy-policy"
       aria-labelledby="privacy-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="privacy-heading"
@@ -97,7 +97,7 @@ export default function PrivacyClient() {
             If you have questions about this policy, please{" "}
             <Link
               href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
               aria-label="Go to Contact page"
             >
               get in touch

--- a/app/terms/terms-client.tsx
+++ b/app/terms/terms-client.tsx
@@ -9,7 +9,7 @@ export default function TermsClient() {
     <section
       id="terms-of-use"
       aria-labelledby="terms-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-brand-200 selection:text-brand-900"
     >
       <h1
         id="terms-heading"
@@ -23,7 +23,7 @@ export default function TermsClient() {
         “Service”), you agree to these Terms of Use and our{" "}
         <Link
           href="/privacy"
-          className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+          className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
         >
           Privacy Policy
         </Link>
@@ -118,7 +118,7 @@ export default function TermsClient() {
             If you have any questions about these terms, please{" "}
             <Link
               href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
+              className="text-brand-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded transition-colors"
             >
               get in touch
             </Link>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -96,7 +96,7 @@ export default function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={label}
-                  className="text-gray-500 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                  className="text-gray-500 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                 >
                   {icon}
                 </a>
@@ -117,7 +117,7 @@ export default function Footer() {
                 <li key={href} className="list-none">
                   <Link
                     href={href}
-                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                   >
                     {label}
                   </Link>
@@ -139,7 +139,7 @@ export default function Footer() {
                 <li key={href} className="list-none">
                   <Link
                     href={href}
-                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                   >
                     {label}
                   </Link>
@@ -158,7 +158,7 @@ export default function Footer() {
                     href={href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded transition-colors"
+                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 rounded transition-colors"
                   >
                     {label}
                   </a>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -50,7 +50,7 @@ export default function Navbar() {
       {/* Skip link */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-brand-600 text-white rounded-md"
       >
         Skip to main content
       </a>
@@ -87,10 +87,10 @@ export default function Navbar() {
                 aria-current={active ? "page" : undefined}
                 className={`
                   relative text-sm font-medium transition-colors
-                  focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2
+                  focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2
                   ${
                     active
-                      ? "text-indigo-600 after:absolute after:-bottom-1 after:left-0 after:w-full after:h-0.5 after:bg-indigo-600"
+                      ? "text-brand-600 after:absolute after:-bottom-1 after:left-0 after:w-full after:h-0.5 after:bg-brand-600"
                       : "text-gray-700 hover:text-gray-900"
                   }
                 `}
@@ -108,7 +108,7 @@ export default function Navbar() {
           aria-label={isOpen ? "Close menu" : "Open menu"}
           aria-expanded={isOpen}
           aria-controls="mobile-menu"
-          className="md:hidden p-2 rounded-md text-gray-800 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition"
+          className="md:hidden p-2 rounded-md text-gray-800 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 transition"
         >
           {isOpen ? (
             <X className="w-6 h-6" aria-hidden="true" />
@@ -139,10 +139,10 @@ export default function Navbar() {
                     aria-current={active ? "page" : undefined}
                     className={`
                       block w-full px-4 py-2 text-base font-medium rounded-md transition-colors
-                      focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2
                       ${
                         active
-                          ? "bg-indigo-50 text-indigo-600"
+                          ? "bg-brand-50 text-brand-600"
                           : "text-gray-700 hover:bg-gray-100 hover:text-gray-900"
                       }
                     `}

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,7 +1,7 @@
 "use client";
 export default function Spinner({ className = "" }: { className?: string }) {
   return (
-    <div className={`animate-spin rounded-full h-8 w-8 border-4 border-indigo-500 border-t-transparent ${className}`} role="status" aria-label="Loading" />
+    <div className={`animate-spin rounded-full h-8 w-8 border-4 border-brand-500 border-t-transparent ${className}`} role="status" aria-label="Loading" />
   );
 }
 

--- a/components/ToolProviders.tsx
+++ b/components/ToolProviders.tsx
@@ -13,7 +13,7 @@ export default function ToolProviders({ children }: { children: ReactNode }) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="fixed bottom-4 right-4 z-50 px-3 py-2 bg-indigo-600 text-white rounded-full shadow-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        className="fixed bottom-4 right-4 z-50 px-3 py-2 bg-brand-600 text-white rounded-full shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-500"
         aria-label="Toggle tool settings"
       >
         ⚙️

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gearizen-app",
       "version": "1.0.0",
       "dependencies": {
+        "@fontsource/inter": "^5.2.6",
         "bcryptjs": "^3.0.2",
         "diff": "^8.0.2",
         "docx": "^9.5.1",
@@ -951,6 +952,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.6.tgz",
+      "integrity": "sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postbuild": "next-sitemap"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.6",
     "bcryptjs": "^3.0.2",
     "diff": "^8.0.2",
     "docx": "^9.5.1",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,8 +16,8 @@ module.exports = {
     },
     extend: {
       fontFamily: {
-        sans: [...defaultTheme.fontFamily.sans],
-        display: [...defaultTheme.fontFamily.sans],
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+        display: ['Inter', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         brand: {


### PR DESCRIPTION
## Summary
- add Inter font via fontsource and apply globally
- introduce `brand` color palette in Tailwind config
- update buttons, inputs and links to use brand colors
- tweak navbar, layout and footer styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870e73e7dd083258cb8e885de6093fa