### PR TITLE
Improve fonts and hero styling

### DIFF
--- a/app/about/about-client.tsx
+++ b/app/about/about-client.tsx
@@ -14,7 +14,7 @@ export default function AboutClient() {
       {/* Heading */}
       <h1
         id="about-heading"
-        className="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-6 tracking-tight text-center text-gray-900"
+        className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold mb-6 tracking-tight text-center"
       >
         About Gearizen
       </h1>

--- a/app/contact/contact-client.tsx
+++ b/app/contact/contact-client.tsx
@@ -11,7 +11,7 @@ export default function ContactClient() {
     >
       <h1
         id="contact-heading"
-        className="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-8 tracking-tight text-center"
+        className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold mb-8 tracking-tight text-center"
       >
         Contact Us
       </h1>

--- a/app/cookies/cookies-client.tsx
+++ b/app/cookies/cookies-client.tsx
@@ -14,7 +14,7 @@ export default function CookiesClient() {
       {/* Başlık */}
       <h1
         id="cookie-heading"
-        className="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-6 tracking-tight text-center text-gray-900"
+        className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold mb-6 tracking-tight text-center"
       >
         Cookie Policy
       </h1>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,15 +1,29 @@
-'use client';
-import Link from 'next/link';
+"use client";
+import Link from "next/link";
 
 export default function GlobalError({ reset }: { reset: () => void }) {
   return (
     <html>
       <body className="min-h-screen flex flex-col items-center justify-center text-center bg-white text-gray-900 p-8">
-        <h1 className="text-4xl font-bold mb-4">Something went wrong</h1>
-        <p className="mb-6">An unexpected error occurred. Please try again or return home.</p>
+        <h1 className="gradient-text text-4xl font-bold mb-4">
+          Something went wrong
+        </h1>
+        <p className="mb-6">
+          An unexpected error occurred. Please try again or return home.
+        </p>
         <div className="space-x-4">
-          <button onClick={reset} className="px-4 py-2 rounded bg-indigo-600 text-white">Try Again</button>
-          <Link href="/" className="px-4 py-2 rounded bg-gray-200 text-gray-900">Home</Link>
+          <button
+            onClick={reset}
+            className="px-4 py-2 rounded bg-indigo-600 text-white"
+          >
+            Try Again
+          </button>
+          <Link
+            href="/"
+            className="px-4 py-2 rounded bg-gray-200 text-gray-900"
+          >
+            Home
+          </Link>
         </div>
       </body>
     </html>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,13 +1,19 @@
 @import "tailwindcss";
 
 @layer base {
+  html {
+    @apply scroll-smooth;
+  }
+  body {
+    @apply font-sans text-gray-900 bg-white antialiased;
+  }
   h1,
   h2,
   h3,
   h4,
   h5,
   h6 {
-    font-family: theme('fontFamily.sans');
+    font-family: theme("fontFamily.sans");
   }
 }
 
@@ -23,5 +29,8 @@
   }
   .container-responsive {
     @apply container mx-auto px-4 sm:px-6 md:px-8 lg:px-12;
+  }
+  .gradient-text {
+    @apply bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,6 @@ import Footer from "@/components/Footer";
 import ToolProviders from "@/components/ToolProviders";
 import AnalyticsLoader from "./components/AnalyticsLoader";
 
-
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
   title: {
@@ -77,6 +76,16 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     >
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+          rel="stylesheet"
+        />
         <link
           rel="preconnect"
           href="https://www.googletagmanager.com"
@@ -85,7 +94,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <meta name="google-adsense-account" content="ca-pub-2108375251131552" />
         <AnalyticsLoader />
       </head>
-      <body className="flex min-h-screen flex-col">
+      <body className="font-sans flex min-h-screen flex-col">
         <ToolProviders>
           {/* Accessible skip link */}
           <a
@@ -98,16 +107,16 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           {/* Primary navigation */}
           <Navbar />
 
-        {/* Main content area */}
-        <main
-          id="main-content"
-          role="main"
-          tabIndex={-1}
-          aria-label="Main content"
-          className="flex-grow container-responsive py-12"
-        >
-          {children}
-        </main>
+          {/* Main content area */}
+          <main
+            id="main-content"
+            role="main"
+            tabIndex={-1}
+            aria-label="Main content"
+            className="flex-grow container-responsive py-12"
+          >
+            {children}
+          </main>
 
           {/* Footer */}
           <Footer />

--- a/app/not-found/not-found-client.tsx
+++ b/app/not-found/not-found-client.tsx
@@ -26,7 +26,7 @@ export default function NotFoundClient() {
       >
         404
       </h1>
-      <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 mb-6">
+      <h2 className="gradient-text text-2xl sm:text-3xl font-semibold mb-6">
         Oops! Page Not Found
       </h2>
       <p className="max-w-xl text-base sm:text-lg text-gray-700 mb-8 leading-relaxed">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default function HomePage() {
       >
         <h1
           id="hero-heading"
-          className="text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight text-gray-900"
+          className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight"
         >
           Gearizen
         </h1>

--- a/app/privacy/privacy-client.tsx
+++ b/app/privacy/privacy-client.tsx
@@ -13,7 +13,7 @@ export default function PrivacyClient() {
     >
       <h1
         id="privacy-heading"
-        className="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-8 tracking-tight text-center"
+        className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold mb-8 tracking-tight text-center"
       >
         Privacy Policy
       </h1>

--- a/app/terms/terms-client.tsx
+++ b/app/terms/terms-client.tsx
@@ -13,7 +13,7 @@ export default function TermsClient() {
     >
       <h1
         id="terms-heading"
-        className="text-4xl sm:text-5xl md:text-6xl font-extrabold text-center mb-8 tracking-tight"
+        className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold text-center mb-8 tracking-tight"
       >
         Terms of Use
       </h1>


### PR DESCRIPTION
## Summary
- load Inter webfont and apply globally
- add gradient-text utility
- update hero headings across pages
- make body use Inter font

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870e73e7dd083258cb8e885de6093fa