### PR TITLE
Refine page styling with unified hero layout

### DIFF
--- a/app/about/about-client.tsx
+++ b/app/about/about-client.tsx
@@ -9,7 +9,7 @@ export default function AboutClient() {
     <section
       id="about-gearizen"
       aria-labelledby="about-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="hero-section"
     >
       {/* Heading */}
       <h1

--- a/app/contact/contact-client.tsx
+++ b/app/contact/contact-client.tsx
@@ -7,7 +7,7 @@ export default function ContactClient() {
     <section
       id="contact-gearizen"
       aria-labelledby="contact-heading"
-      className="container-responsive py-20 text-gray-900"
+      className="hero-section"
     >
       <h1
         id="contact-heading"

--- a/app/cookies/cookies-client.tsx
+++ b/app/cookies/cookies-client.tsx
@@ -9,7 +9,7 @@ export default function CookiesClient() {
     <section
       id="cookie-policy"
       aria-labelledby="cookie-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="hero-section"
     >
       {/* Başlık */}
       <h1

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,4 +33,7 @@
   .gradient-text {
     @apply bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent;
   }
+  .hero-section {
+    @apply container mx-auto px-4 sm:px-6 md:px-8 lg:px-12 py-20 bg-gradient-to-b from-indigo-50 via-white to-white text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900;
+  }
 }

--- a/app/not-found/not-found-client.tsx
+++ b/app/not-found/not-found-client.tsx
@@ -16,7 +16,7 @@ export default function NotFoundClient() {
     <section
       id="notfound-section"
       aria-labelledby="notfound-title"
-      className="container-responsive py-20 flex flex-col items-center justify-center min-h-screen text-center text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="hero-section flex flex-col items-center justify-center min-h-screen text-center"
     >
       <h1
         id="notfound-title"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -103,7 +103,7 @@ export default function HomePage() {
       {/* Hero */}
       <section
         aria-labelledby="hero-heading"
-        className="container-responsive pt-20 pb-16 text-center"
+        className="hero-section text-center pb-16"
       >
         <h1
           id="hero-heading"

--- a/app/privacy/privacy-client.tsx
+++ b/app/privacy/privacy-client.tsx
@@ -9,7 +9,7 @@ export default function PrivacyClient() {
     <section
       id="privacy-policy"
       aria-labelledby="privacy-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="hero-section"
     >
       <h1
         id="privacy-heading"

--- a/app/terms/terms-client.tsx
+++ b/app/terms/terms-client.tsx
@@ -9,7 +9,7 @@ export default function TermsClient() {
     <section
       id="terms-of-use"
       aria-labelledby="terms-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="hero-section"
     >
       <h1
         id="terms-heading"

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -253,7 +253,7 @@ export default function ToolsClient() {
     <section
       id="all-tools"
       aria-labelledby="all-tools-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900 space-y-12"
+      className="hero-section space-y-12"
     >
       {/* Hero */}
       <header className="text-center max-w-3xl mx-auto space-y-4">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -44,7 +44,7 @@ export default function Navbar() {
 
   return (
     <header
-      className="sticky top-0 z-50 bg-white border-b border-gray-200"
+      className="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm"
       role="banner"
     >
       {/* Skip link */}


### PR DESCRIPTION
## Summary
- introduce `hero-section` class in `globals.css`
- apply new hero layout to content pages and tools list
- soften Navbar design with a header shadow

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870ec6c45188325bf7b990b38ffde1b