### PR TITLE
Add new text case and XML formatter tools

### DIFF
--- a/__tests__/convert-case.test.ts
+++ b/__tests__/convert-case.test.ts
@@ -1,0 +1,13 @@
+import { convertCase } from "../lib/convert-case";
+
+describe("convertCase", () => {
+  test("upper case", () => {
+    expect(convertCase("hello", "upper")).toBe("HELLO");
+  });
+  test("camel case", () => {
+    expect(convertCase("hello world", "camel")).toBe("helloWorld");
+  });
+  test("snake case", () => {
+    expect(convertCase("Hello World", "snake")).toBe("hello_world");
+  });
+});

--- a/app/tools/text-case-converter/page.tsx
+++ b/app/tools/text-case-converter/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+import TextCaseConverterClient from "./text-case-converter-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "Text Case Converter",
+  description:
+    "Transform text between upper, lower, title, sentence, camel, snake and kebab cases entirely in your browser.",
+  keywords: [
+    "text case converter",
+    "uppercase",
+    "lowercase",
+    "camel case",
+    "snake case",
+    "kebab case",
+    "Gearizen tools",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/text-case-converter" },
+  openGraph: {
+    title: "Text Case Converter | Gearizen",
+    description:
+      "Quickly switch text between different cases with this free, client-side tool.",
+    url: "https://gearizen.com/tools/text-case-converter",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen Text Case Converter",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Text Case Converter | Gearizen",
+    description:
+      "Convert text to upper, lower, camel, snake and more—100% client-side and free.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function TextCaseConverterPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Text Case Converter"
+        pageUrl="https://gearizen.com/tools/text-case-converter"
+      />
+      <TextCaseConverterClient />
+    </>
+  );
+}

--- a/app/tools/text-case-converter/text-case-converter-client.tsx
+++ b/app/tools/text-case-converter/text-case-converter-client.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { convertCase, CaseType } from "@/lib/convert-case";
+
+const cases: { label: string; value: CaseType }[] = [
+  { label: "UPPERCASE", value: "upper" },
+  { label: "lowercase", value: "lower" },
+  { label: "Title Case", value: "title" },
+  { label: "Sentence case", value: "sentence" },
+  { label: "camelCase", value: "camel" },
+  { label: "snake_case", value: "snake" },
+  { label: "kebab-case", value: "kebab" },
+];
+
+export default function TextCaseConverterClient() {
+  const [input, setInput] = useState("");
+  const [target, setTarget] = useState<CaseType>("upper");
+  const output = convertCase(input, target);
+
+  const copyOutput = async () => {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      alert("✅ Output copied to clipboard!");
+    } catch {
+      alert("❌ Failed to copy output.");
+    }
+  };
+
+  return (
+    <section
+      id="text-case-converter"
+      aria-labelledby="text-case-converter-heading"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="text-case-converter-heading"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        Text Case Converter
+      </h1>
+      <p className="text-center text-gray-600 mb-8 max-w-2xl mx-auto leading-relaxed">
+        Type or paste text and choose a case style to convert instantly.
+      </p>
+
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        rows={6}
+        placeholder="Enter your text..."
+        className="w-full max-w-3xl mx-auto block border border-gray-300 rounded-lg p-4 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition resize-y"
+      />
+
+      <div className="mt-4 flex flex-wrap justify-center gap-3">
+        {cases.map(({ label, value }) => (
+          <label key={value} className="flex items-center space-x-2">
+            <input
+              type="radio"
+              name="case"
+              value={value}
+              checked={target === value}
+              onChange={() => setTarget(value)}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+            />
+            <span className="text-sm select-none">{label}</span>
+          </label>
+        ))}
+      </div>
+
+      {output && (
+        <div className="mt-6 max-w-3xl mx-auto">
+          <label htmlFor="case-output" className="sr-only">
+            Converted text
+          </label>
+          <textarea
+            id="case-output"
+            aria-label="Converted text output"
+            value={output}
+            readOnly
+            rows={6}
+            className="w-full border border-gray-300 rounded-lg p-4 font-mono bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          />
+          <button
+            type="button"
+            onClick={copyOutput}
+            className="mt-4 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          >
+            Copy Output
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -239,6 +239,18 @@ const tools: Tool[] = [
     title: "YAML ⇄ JSON Converter",
     description: "Convert YAML to JSON or JSON to YAML in-browser.",
   },
+  {
+    href: "/tools/text-case-converter",
+    Icon: Type,
+    title: "Text Case Converter",
+    description: "Convert text between upper, lower, camel, snake and more.",
+  },
+  {
+    href: "/tools/xml-formatter",
+    Icon: FileCode,
+    title: "XML Formatter",
+    description: "Beautify or minify XML documents instantly.",
+  },
 ];
 
 export default function ToolsClient() {

--- a/app/tools/xml-formatter/page.tsx
+++ b/app/tools/xml-formatter/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import XmlFormatterClient from "./xml-formatter-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "XML Formatter & Minifier",
+  description:
+    "Beautify or minify XML documents directly in your browser with Gearizen's free tool.",
+  keywords: [
+    "xml formatter",
+    "xml beautifier",
+    "xml minifier",
+    "format xml",
+    "Gearizen tools",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/xml-formatter" },
+  openGraph: {
+    title: "XML Formatter & Minifier | Gearizen",
+    description:
+      "Format or compress XML data instantly—privacy-first and client-side.",
+    url: "https://gearizen.com/tools/xml-formatter",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen XML Formatter",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "XML Formatter & Minifier | Gearizen",
+    description:
+      "Easily prettify or minify XML online with no server interaction.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function XmlFormatterPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="XML Formatter & Minifier"
+        pageUrl="https://gearizen.com/tools/xml-formatter"
+      />
+      <XmlFormatterClient />
+    </>
+  );
+}

--- a/app/tools/xml-formatter/xml-formatter-client.tsx
+++ b/app/tools/xml-formatter/xml-formatter-client.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, ChangeEvent } from "react";
+import { html as beautify } from "js-beautify";
+
+export default function XmlFormatterClient() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [minify, setMinify] = useState(false);
+  const [indentSize, setIndentSize] = useState(2);
+
+  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value);
+    setError(null);
+    setOutput("");
+  };
+
+  const runFormat = () => {
+    setError(null);
+    try {
+      const opts = minify
+        ? { indent_size: 0, max_preserve_newlines: 0, wrap_line_length: 0 }
+        : { indent_size: indentSize };
+      const result = beautify(input, opts);
+      setOutput(result);
+    } catch {
+      setError("Error formatting XML. Please check your input.");
+    }
+  };
+
+  const copyToClipboard = async () => {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      alert("✅ Output copied to clipboard!");
+    } catch {
+      alert("❌ Failed to copy output.");
+    }
+  };
+
+  const downloadOutput = () => {
+    if (!output) return;
+    const blob = new Blob([output], { type: "application/xml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "formatted.xml";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section
+      id="xml-formatter"
+      aria-labelledby="xml-formatter-heading"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="xml-formatter-heading"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        XML Formatter & Minifier
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Paste or type your XML below to beautify or minify it. 100% client-side, no signup required.
+      </p>
+
+      <label htmlFor="xml-input" className="sr-only">
+        XML Input
+      </label>
+      <textarea
+        id="xml-input"
+        aria-label="XML input"
+        value={input}
+        onChange={handleInputChange}
+        placeholder="<note><to>User</to></note>"
+        rows={10}
+        className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+      />
+
+      <div className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
+        <div className="flex items-center space-x-4">
+          <label htmlFor="indent-size-xml" className="flex items-center space-x-2">
+            <span className="text-sm font-medium text-gray-700">Indent Size:</span>
+            <select
+              id="indent-size-xml"
+              value={indentSize}
+              onChange={(e) => setIndentSize(Number(e.target.value))}
+              disabled={minify}
+              className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+            >
+              <option value={0}>0</option>
+              <option value={2}>2</option>
+              <option value={4}>4</option>
+              <option value={8}>8</option>
+            </select>
+          </label>
+
+          <label htmlFor="minify-xml" className="flex items-center space-x-2">
+            <input
+              id="minify-xml"
+              type="checkbox"
+              checked={minify}
+              onChange={() => setMinify(!minify)}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+            />
+            <span className="text-sm text-gray-700">Minify</span>
+          </label>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={runFormat}
+            className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          >
+            Format / Minify
+          </button>
+          <button
+            type="button"
+            onClick={copyToClipboard}
+            disabled={!output}
+            className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 transition text-sm font-medium disabled:opacity-60"
+          >
+            Copy
+          </button>
+          <button
+            type="button"
+            onClick={downloadOutput}
+            disabled={!output}
+            className="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition text-sm font-medium disabled:opacity-60"
+          >
+            Download
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-6 p-4 bg-red-50 text-red-700 border border-red-200 rounded-md"
+        >
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
+
+      {output && (
+        <>
+          <label htmlFor="xml-output" className="sr-only">
+            XML Output
+          </label>
+          <textarea
+            id="xml-output"
+            aria-label="Formatted XML output"
+            value={output}
+            readOnly
+            rows={10}
+            className="mt-6 w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          />
+        </>
+      )}
+    </section>
+  );
+}

--- a/lib/convert-case.ts
+++ b/lib/convert-case.ts
@@ -1,0 +1,53 @@
+export type CaseType =
+  | "upper"
+  | "lower"
+  | "title"
+  | "sentence"
+  | "camel"
+  | "snake"
+  | "kebab";
+
+function words(text: string): string[] {
+  return text
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .split(/\s+/);
+}
+
+/** Convert text to the specified case */
+export function convertCase(text: string, type: CaseType): string {
+  switch (type) {
+    case "upper":
+      return text.toUpperCase();
+    case "lower":
+      return text.toLowerCase();
+    case "title":
+      return text
+        .toLowerCase()
+        .replace(/\b(\p{L})/gu, (m) => m.toUpperCase());
+    case "sentence":
+      return text
+        .toLowerCase()
+        .replace(/(^\s*\p{L}|[.!?]\s*\p{L})/gu, (m) => m.toUpperCase());
+    case "camel": {
+      const w = words(text);
+      return w
+        .map((word, i) =>
+          i === 0
+            ? word.toLowerCase()
+            : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+        )
+        .join("");
+    }
+    case "snake":
+      return words(text)
+        .map((w) => w.toLowerCase())
+        .join("_");
+    case "kebab":
+      return words(text)
+        .map((w) => w.toLowerCase())
+        .join("-");
+    default:
+      return text;
+  }
+}


### PR DESCRIPTION
## Summary
- add utilities for converting text into different cases
- add text case converter pages and UI
- add XML formatter tool with interactive client
- list new tools on the Tools page
- test convert case utility

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870f47da60483258f435b71dd6bddaa