### PR TITLE
Add JSON to CSV converter tool

### DIFF
--- a/__tests__/json-to-csv.test.ts
+++ b/__tests__/json-to-csv.test.ts
@@ -1,0 +1,20 @@
+import { jsonToCsv } from '../lib/jsonToCsv';
+
+describe('jsonToCsv', () => {
+  test('converts array of objects to csv', () => {
+    const data = [
+      { name: 'Alice', age: 30 },
+      { name: 'Bob', age: 25 }
+    ];
+    const csv = jsonToCsv(data);
+    expect(csv).toBe('name,age\nAlice,30\nBob,25');
+  });
+
+  test('escapes quotes and commas', () => {
+    const data = [
+      { text: 'Hello, "World"' }
+    ];
+    const csv = jsonToCsv(data);
+    expect(csv).toBe('text\n"Hello, ""World"""');
+  });
+});

--- a/app/tools/json-to-csv/json-to-csv-client.tsx
+++ b/app/tools/json-to-csv/json-to-csv-client.tsx
@@ -1,0 +1,123 @@
+// app/tools/json-to-csv/json-to-csv-client.tsx
+"use client";
+
+import { useState, ChangeEvent, useEffect } from "react";
+import useDebounce from "@/lib/useDebounce";
+import { jsonToCsv } from "@/lib/jsonToCsv";
+
+export default function JsonToCsvClient() {
+  const [jsonText, setJsonText] = useState("");
+  const [csvText, setCsvText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const debouncedJson = useDebounce(jsonText);
+
+  useEffect(() => {
+    if (!debouncedJson.trim()) {
+      setCsvText("");
+      return;
+    }
+    try {
+      const parsed = JSON.parse(debouncedJson);
+      if (!Array.isArray(parsed)) {
+        throw new Error("JSON must be an array of objects");
+      }
+      setCsvText(jsonToCsv(parsed));
+      setError(null);
+    } catch (err) {
+      setCsvText("");
+      setError(err instanceof Error ? err.message : "Invalid JSON data");
+    }
+  }, [debouncedJson]);
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setJsonText(e.target.value);
+    setError(null);
+  };
+
+  const copyCsv = async () => {
+    if (!csvText) return;
+    try {
+      await navigator.clipboard.writeText(csvText);
+      alert("✅ CSV copied to clipboard!");
+    } catch {
+      alert("❌ Failed to copy CSV.");
+    }
+  };
+
+  const downloadCsv = () => {
+    if (!csvText) return;
+    const blob = new Blob([csvText], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "data.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section
+      id="json-to-csv"
+      aria-labelledby="json-to-csv-heading"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1 id="json-to-csv-heading" className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight">
+        JSON to CSV Converter
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Paste your JSON array to convert it into CSV format. 100% client-side, no signup required.
+      </p>
+
+      <div className="max-w-4xl mx-auto space-y-6" aria-label="JSON to CSV form">
+        <div>
+          <label htmlFor="json-input" className="block mb-1 font-medium text-gray-800">
+            JSON Input
+          </label>
+          <textarea
+            id="json-input"
+            value={jsonText}
+            onChange={handleChange}
+            placeholder='[{"name":"Alice","age":30},{"name":"Bob","age":25}]'
+            rows={8}
+            className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-red-600 text-sm">
+            {error}
+          </p>
+        )}
+      </div>
+
+      {csvText && (
+        <div className="mt-12 max-w-4xl mx-auto space-y-6">
+          <label htmlFor="csv-output" className="block mb-1 font-medium text-gray-800">
+            CSV Output
+          </label>
+          <textarea
+            id="csv-output"
+            readOnly
+            value={csvText}
+            rows={10}
+            className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          />
+          <div className="flex justify-center gap-4">
+            <button
+              onClick={copyCsv}
+              className="px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 transition text-sm font-medium"
+            >
+              Copy CSV
+            </button>
+            <button
+              onClick={downloadCsv}
+              className="px-6 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition text-sm font-medium"
+            >
+              Download CSV
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/tools/json-to-csv/page.tsx
+++ b/app/tools/json-to-csv/page.tsx
@@ -1,0 +1,54 @@
+// app/tools/json-to-csv/page.tsx
+import JsonToCsvClient from "./json-to-csv-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+
+export const metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "JSON to CSV Converter",
+  description:
+    "Convert JSON arrays into CSV instantly with Gearizen’s free client-side JSON to CSV Converter. Paste, convert, copy or download—no signup required.",
+  keywords: [
+    "json to csv",
+    "csv converter",
+    "client-side json tool",
+    "free json to csv",
+    "Gearizen json csv",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/json-to-csv" },
+  openGraph: {
+    title: "JSON to CSV Converter | Gearizen",
+    description:
+      "Use Gearizen’s client-side JSON to CSV Converter to quickly transform JSON arrays into CSV data. Copy or download instantly.",
+    url: "https://gearizen.com/tools/json-to-csv",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen JSON to CSV Converter",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "JSON to CSV Converter | Gearizen",
+    description:
+      "Instantly convert JSON arrays to CSV in your browser with Gearizen’s client-side converter. Fast, private, and free—no login needed.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function JsonToCsvPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd pageTitle="JSON to CSV Converter" pageUrl="https://gearizen.com/tools/json-to-csv" />
+      <JsonToCsvClient />
+    </>
+  );
+}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -29,6 +29,7 @@ export const metadata = {
     "PDF compressor",
     "PDF to Word",
     "CSV to JSON",
+    "JSON to CSV",
     "HTML formatter",
     "HTML to PDF",
     "SEO meta tag generator",

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -35,6 +35,7 @@ import {
   Link as LinkIcon,
   Hash,
   Braces,
+  Table,
 } from "lucide-react";
 
 interface Tool {
@@ -150,6 +151,13 @@ const tools: Tool[] = [
     title: "CSV → JSON Converter",
     description:
       "Transform CSV data into JSON arrays quickly, entirely in-browser.",
+  },
+  {
+    href: "/tools/json-to-csv",
+    Icon: Table,
+    title: "JSON → CSV Converter",
+    description:
+      "Turn JSON arrays into CSV data instantly, 100% client-side.",
   },
   {
     href: "/tools/html-to-pdf",

--- a/lib/jsonToCsv.ts
+++ b/lib/jsonToCsv.ts
@@ -1,0 +1,19 @@
+export function jsonToCsv(data: unknown[], delimiter = ','): string {
+  if (!Array.isArray(data) || data.length === 0) return '';
+
+  const keys = Object.keys(data[0] as Record<string, unknown>);
+  const rows = [keys.join(delimiter)];
+
+  for (const item of data) {
+    const row = keys.map((key) => {
+      const val = (item as Record<string, unknown>)[key];
+      if (val === null || val === undefined) return '';
+      const str = String(val);
+      const needsQuote = str.includes('"') || str.includes(delimiter) || str.includes('\n');
+      return needsQuote ? '"' + str.replace(/"/g, '""') + '"' : str;
+    });
+    rows.push(row.join(delimiter));
+  }
+
+  return rows.join('\n');
+}


### PR DESCRIPTION
## Summary
- add JSON→CSV converter with metadata and interactive UI
- support conversion with new `jsonToCsv` util
- expose tool in tools list and update SEO keywords
- test the `jsonToCsv` conversion

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68712f207448832594780ef49e27e792