### PR TITLE
Add URL Parser tool

### DIFF
--- a/__tests__/parse-url.test.ts
+++ b/__tests__/parse-url.test.ts
@@ -1,0 +1,22 @@
+import { parseUrl } from "../lib/parse-url";
+
+describe("parseUrl", () => {
+  test("parses standard URL", () => {
+    const res = parseUrl("https://example.com:8080/path?x=1#top");
+    expect(res.protocol).toBe("https:");
+    expect(res.host).toBe("example.com:8080");
+    expect(res.pathname).toBe("/path");
+    expect(res.hash).toBe("#top");
+    expect(res.params).toEqual({ x: "1" });
+  });
+
+  test("adds protocol if missing", () => {
+    const res = parseUrl("example.com/foo");
+    expect(res.hostname).toBe("example.com");
+    expect(res.pathname).toBe("/foo");
+  });
+
+  test("throws on invalid input", () => {
+    expect(() => parseUrl("???")).toThrow("Invalid URL");
+  });
+});

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -31,6 +31,7 @@ export const metadata = {
     "CSV to JSON",
     "HTML formatter",
     "HTML to PDF",
+    "URL parser",
     "SEO meta tag generator",
     "JWT decoder",
     "word counter",

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -37,6 +37,7 @@ import {
   Calculator,
   Palette,
   ListOrdered,
+  Search,
 } from "lucide-react";
 
 interface Tool {
@@ -227,6 +228,13 @@ const tools: Tool[] = [
     Icon: LinkIcon,
     title: "URL Encoder/Decoder",
     description: "Encode or decode URLs and query strings.",
+  },
+  {
+    href: "/tools/url-parser",
+    Icon: Search,
+    title: "URL Parser",
+    description:
+      "Break down URLs to view protocol, host, path and query parameters.",
   },
   {
     href: "/tools/base-converter",

--- a/app/tools/url-parser/page.tsx
+++ b/app/tools/url-parser/page.tsx
@@ -1,0 +1,53 @@
+import UrlParserClient from "./url-parser-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+
+export const metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "URL Parser",
+  description:
+    "Analyze any URL to view protocol, host, pathname, query parameters and more. All client-side with no tracking.",
+  keywords: [
+    "url parser",
+    "link analyzer",
+    "query parameters",
+    "client-side url tools",
+    "Gearizen url parser",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/url-parser" },
+  openGraph: {
+    title: "URL Parser | Gearizen",
+    description:
+      "Break down URLs into components with Gearizen's client-side URL Parser. Inspect protocol, host and query params easily.",
+    url: "https://gearizen.com/tools/url-parser",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen URL Parser",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "URL Parser | Gearizen",
+    description:
+      "Use Gearizen's URL Parser to decompose links into protocol, path and parameters—all in your browser.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function UrlParserPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd pageTitle="URL Parser" pageUrl="https://gearizen.com/tools/url-parser" />
+      <UrlParserClient />
+    </>
+  );
+}

--- a/app/tools/url-parser/url-parser-client.tsx
+++ b/app/tools/url-parser/url-parser-client.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { parseUrl, ParsedUrl } from "../../../lib/parse-url";
+
+export default function UrlParserClient() {
+  const [input, setInput] = useState("");
+  const [result, setResult] = useState<ParsedUrl | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleParse = () => {
+    try {
+      const parsed = parseUrl(input.trim());
+      setResult(parsed);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Invalid URL");
+      setResult(null);
+    }
+  };
+
+  const copyJson = async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(result, null, 2));
+      alert("✅ Copied!");
+    } catch {
+      alert("❌ Failed to copy");
+    }
+  };
+
+  return (
+    <section
+      id="url-parser"
+      aria-labelledby="url-parser-heading"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="url-parser-heading"
+        className="text-4xl sm:text-5xl md:text-6xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        URL Parser
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Decompose any URL into its individual components directly in your browser.
+      </p>
+
+      <div className="max-w-xl mx-auto space-y-6">
+        <div>
+          <label htmlFor="url-input" className="block mb-1 font-medium text-gray-800">
+            URL
+          </label>
+          <input
+            id="url-input"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="https://example.com/path?foo=1#section"
+            className="input-base"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-4">
+          <button type="button" onClick={handleParse} className="btn-primary">
+            Parse
+          </button>
+          <button
+            type="button"
+            onClick={copyJson}
+            disabled={!result}
+            className="btn-secondary disabled:opacity-60"
+          >
+            Copy JSON
+          </button>
+        </div>
+
+        {error && (
+          <p role="alert" className="text-red-600 text-sm">
+            {error}
+          </p>
+        )}
+
+        {result && !error && (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm border border-gray-300 rounded-lg">
+              <tbody className="divide-y divide-gray-200">
+                <tr>
+                  <th className="text-left p-2 font-medium">Protocol</th>
+                  <td className="p-2 font-mono break-all">{result.protocol}</td>
+                </tr>
+                <tr>
+                  <th className="text-left p-2 font-medium">Host</th>
+                  <td className="p-2 font-mono break-all">{result.host}</td>
+                </tr>
+                <tr>
+                  <th className="text-left p-2 font-medium">Pathname</th>
+                  <td className="p-2 font-mono break-all">{result.pathname}</td>
+                </tr>
+                <tr>
+                  <th className="text-left p-2 font-medium">Search</th>
+                  <td className="p-2 font-mono break-all">{result.search}</td>
+                </tr>
+                <tr>
+                  <th className="text-left p-2 font-medium">Hash</th>
+                  <td className="p-2 font-mono break-all">{result.hash}</td>
+                </tr>
+                {Object.keys(result.params).length > 0 && (
+                  <tr>
+                    <th className="text-left p-2 font-medium">Params</th>
+                    <td className="p-2 font-mono break-all whitespace-pre">
+                      {JSON.stringify(result.params, null, 2)}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/lib/parse-url.ts
+++ b/lib/parse-url.ts
@@ -1,0 +1,44 @@
+export interface ParsedUrl {
+  href: string;
+  protocol: string;
+  host: string;
+  hostname: string;
+  port: string;
+  pathname: string;
+  search: string;
+  hash: string;
+  params: Record<string, string>;
+}
+
+/**
+ * Parse a URL string and return its components.
+ * Adds https:// if scheme is missing.
+ */
+export function parseUrl(input: string): ParsedUrl {
+  let url: URL;
+  if (!input) throw new Error("Invalid URL");
+  try {
+    url = new URL(input);
+  } catch {
+    try {
+      url = new URL("https://" + input);
+    } catch {
+      throw new Error("Invalid URL");
+    }
+  }
+  const params: Record<string, string> = {};
+  url.searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+  return {
+    href: url.href,
+    protocol: url.protocol,
+    host: url.host,
+    hostname: url.hostname,
+    port: url.port,
+    pathname: url.pathname,
+    search: url.search,
+    hash: url.hash,
+    params,
+  };
+}


### PR DESCRIPTION
## Summary
- implement new `parseUrl` library
- add `URL Parser` tool page and client component
- include URL Parser in tools listing
- update tools page keywords
- test `parseUrl`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68716eb6b8bc8325823d447a380b67ce