### PR TITLE
Add URL Slug Generator tool

### DIFF
--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -35,6 +35,7 @@ export const metadata = {
     "JWT decoder",
     "word counter",
     "character counter",
+    "slug generator",
   ],
   authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
   robots: { index: true, follow: true },

--- a/app/tools/slug-generator/page.tsx
+++ b/app/tools/slug-generator/page.tsx
@@ -1,0 +1,52 @@
+// app/tools/slug-generator/page.tsx
+import SlugGeneratorClient from "./slug-generator-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+
+export const metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "URL Slug Generator",
+  description:
+    "Create clean, SEO-friendly slugs from any text completely in your browser.",
+  keywords: [
+    "slug generator",
+    "url slug",
+    "seo slug",
+    "slugify",
+    "Gearizen tools",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/slug-generator" },
+  openGraph: {
+    title: "URL Slug Generator | Gearizen",
+    description:
+      "Instantly slugify text for SEO-friendly URLs with Gearizen’s client-side tool.",
+    url: "https://gearizen.com/tools/slug-generator",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      { url: "/og-placeholder.svg", width: 1200, height: 630, alt: "Gearizen Slug Generator" },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "URL Slug Generator | Gearizen",
+    description:
+      "Generate SEO slugs entirely offline with Gearizen—no signup, no tracking.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function SlugGeneratorPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="URL Slug Generator"
+        pageUrl="https://gearizen.com/tools/slug-generator"
+      />
+      <SlugGeneratorClient />
+    </>
+  );
+}

--- a/app/tools/slug-generator/slug-generator-client.tsx
+++ b/app/tools/slug-generator/slug-generator-client.tsx
@@ -1,0 +1,123 @@
+"use client";
+import { useState } from "react";
+import Input from "@/components/Input";
+import Textarea from "@/components/Textarea";
+import { slugify } from "@/lib/slugify";
+
+export default function SlugGeneratorClient() {
+  const [text, setText] = useState("");
+  const [delimiter, setDelimiter] = useState("-");
+  const [lowercase, setLowercase] = useState(true);
+  const [removeStop, setRemoveStop] = useState(false);
+  const [slug, setSlug] = useState("");
+
+  const generate = () => {
+    const result = slugify(text, {
+      delimiter,
+      lowercase,
+      removeStopWords: removeStop,
+    });
+    setSlug(result);
+  };
+
+  const copySlug = async () => {
+    if (!slug) return;
+    try {
+      await navigator.clipboard.writeText(slug);
+      alert("✅ Copied to clipboard!");
+    } catch {
+      alert("❌ Copy failed.");
+    }
+  };
+
+  return (
+    <section
+      id="slug-generator"
+      aria-labelledby="slug-generator-heading"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="slug-generator-heading"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        URL Slug Generator
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Enter text and customize options to generate a clean, SEO-friendly slug.
+      </p>
+
+      <div className="space-y-6 max-w-xl mx-auto">
+        <div>
+          <label htmlFor="slug-input" className="block mb-2 font-medium text-gray-800">
+            Text to Slugify
+          </label>
+          <Textarea
+            id="slug-input"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={4}
+            placeholder="Type your title or phrase..."
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <label className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={lowercase}
+              onChange={() => setLowercase((v) => !v)}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+            />
+            <span className="text-gray-700 select-none">Lowercase</span>
+          </label>
+          <label className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              checked={removeStop}
+              onChange={() => setRemoveStop((v) => !v)}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+            />
+            <span className="text-gray-700 select-none">Remove Stop Words</span>
+          </label>
+        </div>
+
+        <div>
+          <label htmlFor="delimiter" className="block mb-2 font-medium text-gray-800">
+            Delimiter
+          </label>
+          <Input
+            id="delimiter"
+            value={delimiter}
+            onChange={(e) => setDelimiter(e.target.value)}
+            className="w-24"
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={generate}
+          className="w-full py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition font-medium"
+        >
+          Generate Slug
+        </button>
+
+        {slug && (
+          <div className="space-y-4">
+            <label htmlFor="slug-output" className="block mb-2 font-medium text-gray-800">
+              Generated Slug
+            </label>
+            <Input id="slug-output" readOnly value={slug} className="w-full" />
+            <div className="flex justify-end gap-4">
+              <button
+                onClick={copySlug}
+                className="px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 transition text-sm font-medium"
+              >
+                Copy Slug
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -37,6 +37,7 @@ import {
   Calculator,
   Palette,
   ListOrdered,
+  Link2,
 } from "lucide-react";
 
 interface Tool {
@@ -227,6 +228,12 @@ const tools: Tool[] = [
     Icon: LinkIcon,
     title: "URL Encoder/Decoder",
     description: "Encode or decode URLs and query strings.",
+  },
+  {
+    href: "/tools/slug-generator",
+    Icon: Link2,
+    title: "URL Slug Generator",
+    description: "Slugify text into SEO-friendly URLs quickly.",
   },
   {
     href: "/tools/base-converter",

--- a/lib/slugify.ts
+++ b/lib/slugify.ts
@@ -1,0 +1,46 @@
+export interface SlugOptions {
+  delimiter?: string;
+  lowercase?: boolean;
+  removeStopWords?: boolean;
+  stopWords?: string[];
+}
+
+const DEFAULT_STOP_WORDS = [
+  'a',
+  'an',
+  'and',
+  'the',
+  'or',
+  'for',
+  'to',
+  'of',
+  'in',
+];
+
+/**
+ * Create a URL-friendly slug from text.
+ */
+export function slugify(text: string, options: SlugOptions = {}): string {
+  const {
+    delimiter = '-',
+    lowercase = true,
+    removeStopWords = false,
+    stopWords = DEFAULT_STOP_WORDS,
+  } = options;
+
+  // Normalize and remove diacritics
+  let str = text.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+  // Replace non-alphanumeric characters with spaces
+  str = str.replace(/[^\p{L}\p{N}]+/gu, ' ');
+
+  let words = str.trim().split(/\s+/);
+
+  if (removeStopWords) {
+    const set = new Set(stopWords.map((w) => w.toLowerCase()));
+    words = words.filter((w) => !set.has(w.toLowerCase()));
+  }
+
+  let slug = words.join(delimiter);
+  if (lowercase) slug = slug.toLowerCase();
+  return slug;
+}


### PR DESCRIPTION
## Summary
- introduce `slugify` utility
- add new **URL Slug Generator** tool
- include slug generator in Tools list and SEO keywords

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68716eb6b8bc8325823d447a380b67ce