### PR TITLE
Add color palette generator tool

### DIFF
--- a/__tests__/color-palette.test.ts
+++ b/__tests__/color-palette.test.ts
@@ -1,0 +1,15 @@
+import { generatePalette } from '../lib/color-palette';
+
+describe('generatePalette', () => {
+  test('complementary palette', () => {
+    expect(generatePalette('#ff0000', 'complementary')).toEqual(['#ff0000', '#00ffff']);
+  });
+
+  test('triadic palette', () => {
+    expect(generatePalette('#ff0000', 'triadic')).toEqual(['#ff0000', '#00ff00', '#0000ff']);
+  });
+
+  test('analogous count', () => {
+    expect(generatePalette('#ff0000', 'analogous', 5)).toHaveLength(5);
+  });
+});

--- a/app/tools/color-palette-generator/color-palette-generator-client.tsx
+++ b/app/tools/color-palette-generator/color-palette-generator-client.tsx
@@ -1,0 +1,116 @@
+"use client";
+import { useState, ChangeEvent, useEffect } from 'react';
+import Input from '@/components/Input';
+import { generatePalette, PaletteScheme } from '@/lib/color-palette';
+
+export default function ColorPaletteGeneratorClient() {
+  const [color, setColor] = useState('#ff0000');
+  const [scheme, setScheme] = useState<PaletteScheme>('analogous');
+  const [count, setCount] = useState(5);
+  const [palette, setPalette] = useState<string[]>(generatePalette('#ff0000'));
+
+  useEffect(() => {
+    try {
+      setPalette(generatePalette(color, scheme, count));
+    } catch {
+      setPalette([]);
+    }
+  }, [color, scheme, count]);
+
+  const handleColor = (e: ChangeEvent<HTMLInputElement>) => {
+    setColor(e.target.value);
+  };
+
+  return (
+    <section
+      id="color-palette-generator"
+      aria-labelledby="color-palette-generator-heading"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="color-palette-generator-heading"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        Color Palette Generator
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Choose a base color and scheme to instantly generate a matching palette.
+      </p>
+      <div className="max-w-md mx-auto space-y-6">
+        <div>
+          <label htmlFor="base-color" className="block mb-1 font-medium text-gray-800">
+            Base Color
+          </label>
+          <Input id="base-color" type="color" value={color} onChange={handleColor} className="h-10 p-0" />
+        </div>
+        <div className="flex items-center space-x-4">
+          <label className="flex items-center space-x-1">
+            <input
+              type="radio"
+              name="scheme"
+              value="analogous"
+              checked={scheme === 'analogous'}
+              onChange={() => setScheme('analogous')}
+              className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+            />
+            <span className="text-sm text-gray-700">Analogous</span>
+          </label>
+          <label className="flex items-center space-x-1">
+            <input
+              type="radio"
+              name="scheme"
+              value="complementary"
+              checked={scheme === 'complementary'}
+              onChange={() => setScheme('complementary')}
+              className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+            />
+            <span className="text-sm text-gray-700">Complementary</span>
+          </label>
+          <label className="flex items-center space-x-1">
+            <input
+              type="radio"
+              name="scheme"
+              value="triadic"
+              checked={scheme === 'triadic'}
+              onChange={() => setScheme('triadic')}
+              className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+            />
+            <span className="text-sm text-gray-700">Triadic</span>
+          </label>
+        </div>
+        {scheme === 'analogous' && (
+          <div>
+            <label htmlFor="count" className="block mb-1 font-medium text-gray-800">
+              Colors
+            </label>
+            <Input
+              id="count"
+              type="number"
+              min={3}
+              max={9}
+              value={count}
+              onChange={(e) => setCount(Number(e.target.value))}
+              className="w-24"
+            />
+          </div>
+        )}
+      </div>
+      {palette.length > 0 && (
+        <ul className="mt-12 grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-5">
+          {palette.map((hex) => (
+            <li key={hex} className="text-center space-y-2">
+              <div className="h-16 rounded" style={{ backgroundColor: hex }} />
+              <button
+                type="button"
+                onClick={() => navigator.clipboard.writeText(hex)}
+                className="text-sm font-mono px-2 py-1 bg-gray-100 border border-gray-300 rounded-md hover:bg-gray-200"
+              >
+                {hex}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/app/tools/color-palette-generator/page.tsx
+++ b/app/tools/color-palette-generator/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next';
+import ColorPaletteGeneratorClient from './color-palette-generator-client';
+import BreadcrumbJsonLd from '@/app/components/BreadcrumbJsonLd';
+
+export const metadata: Metadata = {
+  metadataBase: new URL('https://gearizen.com'),
+  title: 'Color Palette Generator',
+  description: 'Create harmonious color palettes from any base color directly in your browser.',
+  keywords: ['color palette', 'palette generator', 'color scheme', 'design tool', 'Gearizen tools'],
+  authors: [{ name: 'Gearizen Team', url: 'https://gearizen.com/about' }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: 'https://gearizen.com/tools/color-palette-generator' },
+  openGraph: {
+    title: 'Color Palette Generator | Gearizen',
+    description: 'Build complementary or triadic color schemes offline with Gearizen.',
+    url: 'https://gearizen.com/tools/color-palette-generator',
+    siteName: 'Gearizen',
+    locale: 'en_US',
+    type: 'website',
+    images: [
+      { url: '/og-placeholder.svg', width: 1200, height: 630, alt: 'Gearizen Color Palette Generator' },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Color Palette Generator | Gearizen',
+    description: 'Generate beautiful color palettes with no server needed.',
+    creator: '@gearizen',
+    images: ['/og-placeholder.svg'],
+  },
+};
+
+export default function ColorPaletteGeneratorPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Color Palette Generator"
+        pageUrl="https://gearizen.com/tools/color-palette-generator"
+      />
+      <ColorPaletteGeneratorClient />
+    </>
+  );
+}

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -96,6 +96,12 @@ const tools: Tool[] = [
     description: "Convert colors between HEX, RGB and HSL with preview.",
   },
   {
+    href: "/tools/color-palette-generator",
+    Icon: Palette,
+    title: "Color Palette Generator",
+    description: "Create harmonious color schemes from any base color.",
+  },
+  {
     href: "/tools/base64-encoder-decoder",
     Icon: Paperclip,
     title: "Base64 Encoder/Decoder",

--- a/lib/color-palette.ts
+++ b/lib/color-palette.ts
@@ -1,0 +1,33 @@
+import { hexToRgb, rgbToHex, rgbToHsl, hslToRgb } from './color-conversion';
+
+export type PaletteScheme = 'analogous' | 'complementary' | 'triadic';
+
+/**
+ * Generate a simple color palette from a base HEX color.
+ * @param base - Hex color string like `#ff0000`.
+ * @param scheme - Palette type to create.
+ * @param count - Number of colors for analogous palettes.
+ */
+export function generatePalette(
+  base: string,
+  scheme: PaletteScheme = 'analogous',
+  count = 5,
+): string[] {
+  const rgb = hexToRgb(base);
+  if (!rgb) throw new Error('Invalid hex color');
+  const { h, s, l } = rgbToHsl(rgb);
+  const wrap = (val: number) => ((val % 360) + 360) % 360;
+  const toHex = (hue: number) => rgbToHex(hslToRgb({ h: wrap(hue), s, l }));
+
+  switch (scheme) {
+    case 'complementary':
+      return [base, toHex(h + 180)];
+    case 'triadic':
+      return [base, toHex(h + 120), toHex(h + 240)];
+    default: {
+      const half = Math.floor(count / 2);
+      const step = 30;
+      return Array.from({ length: count }, (_, i) => toHex(h + (i - half) * step));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `generatePalette` utility
- add a color palette generator with SEO metadata
- list new tool on the tools page
- test color palette util

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871a3785d848325b06862185715bc1a