### PR TITLE
Add Caesar Cipher tool

### DIFF
--- a/app/tools/caesar-cipher/caesar-cipher-client.tsx
+++ b/app/tools/caesar-cipher/caesar-cipher-client.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, ChangeEvent } from "react";
+import { caesarCipher } from "../../../lib/caesar-cipher";
+
+export default function CaesarCipherClient() {
+  const [text, setText] = useState("");
+  const [shift, setShift] = useState(13);
+  const [decoded, setDecoded] = useState("");
+
+  const handleEncode = () => {
+    setDecoded(caesarCipher(text, { shift }));
+  };
+
+  const handleDecode = () => {
+    setDecoded(caesarCipher(text, { shift, decode: true }));
+  };
+
+  const handleTextChange = (e: ChangeEvent<HTMLTextAreaElement>) =>
+    setText(e.target.value);
+
+  return (
+    <section className="container-responsive py-20 text-gray-900 space-y-6">
+      <h1 className="text-4xl sm:text-5xl font-extrabold text-center mb-6">
+        Caesar Cipher
+      </h1>
+      <p className="text-center text-gray-700 max-w-2xl mx-auto mb-6">
+        Encode or decode messages with a customizable shift. Only runs in your
+        browser for complete privacy.
+      </p>
+      <div className="max-w-xl mx-auto space-y-4">
+        <textarea
+          value={text}
+          onChange={handleTextChange}
+          placeholder="Enter text..."
+          className="w-full h-32 p-3 border border-gray-300 rounded-lg resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+        <div className="flex items-center gap-4">
+          <label htmlFor="shift" className="font-medium text-gray-800">
+            Shift
+          </label>
+          <input
+            id="shift"
+            type="number"
+            value={shift}
+            onChange={(e) => setShift(parseInt(e.target.value, 10) || 0)}
+            className="w-24 border border-gray-300 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <button onClick={handleEncode} className="btn-primary">
+            Encode
+          </button>
+          <button onClick={handleDecode} className="btn-primary">
+            Decode
+          </button>
+        </div>
+        <textarea
+          readOnly
+          value={decoded}
+          placeholder="Result"
+          className="w-full h-32 p-3 border border-gray-300 rounded-lg bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+      </div>
+    </section>
+  );
+}

--- a/app/tools/caesar-cipher/page.tsx
+++ b/app/tools/caesar-cipher/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import CaesarCipherClient from "./caesar-cipher-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "Caesar Cipher",
+  description:
+    "Encrypt or decrypt text with a custom shift using Gearizen's Caesar Cipher tool—fully client-side and privacy-friendly.",
+  keywords: [
+    "caesar cipher",
+    "text encryption",
+    "text decryption",
+    "client-side cipher",
+    "Gearizen tools",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/caesar-cipher" },
+  openGraph: {
+    title: "Caesar Cipher | Gearizen",
+    description:
+      "Quickly encode or decode messages with the Caesar Cipher directly in your browser—no data leaves your device.",
+    url: "https://gearizen.com/tools/caesar-cipher",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen Caesar Cipher",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Caesar Cipher | Gearizen",
+    description:
+      "Encrypt and decrypt text with a customizable shift—works entirely offline in your browser.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function CaesarCipherPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="Caesar Cipher"
+        pageUrl="https://gearizen.com/tools/caesar-cipher"
+      />
+      <CaesarCipherClient />
+    </>
+  );
+}

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -36,6 +36,7 @@ import {
   Braces,
   Calculator,
   Ampersand,
+  RotateCcw,
   Palette,
   ListOrdered,
   Link2,
@@ -273,6 +274,12 @@ const tools: Tool[] = [
     Icon: Type,
     title: "Text Case Converter",
     description: "Convert text between upper, lower, camel, snake and more.",
+  },
+  {
+    href: "/tools/caesar-cipher",
+    Icon: RotateCcw,
+    title: "Caesar Cipher",
+    description: "Encrypt or decrypt text with a custom shift value.",
   },
   {
     href: "/tools/xml-formatter",

--- a/lib/caesar-cipher.ts
+++ b/lib/caesar-cipher.ts
@@ -1,0 +1,20 @@
+export interface CaesarOptions {
+  shift?: number;
+  decode?: boolean;
+}
+
+/**
+ * Encode or decode text using the Caesar cipher.
+ * Works with basic Latin letters; non-letters are preserved.
+ */
+export function caesarCipher(
+  text: string,
+  { shift = 13, decode = false }: CaesarOptions = {},
+): string {
+  const s = (((decode ? -shift : shift) % 26) + 26) % 26;
+  return text.replace(/[a-z]/gi, (char) => {
+    const base = char <= "Z" ? 65 : 97;
+    const code = char.charCodeAt(0) - base;
+    return String.fromCharCode(((code + s) % 26) + base);
+  });
+}


### PR DESCRIPTION
## Summary
- add new library `caesar-cipher.ts`
- add Caesar Cipher page and client
- list Caesar Cipher in the tools catalog

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871a3785d848325b06862185715bc1a