### PR TITLE
Add CSS Formatter tool

### DIFF
--- a/app/tools/css-formatter/css-formatter-client.tsx
+++ b/app/tools/css-formatter/css-formatter-client.tsx
@@ -1,0 +1,173 @@
+// app/tools/css-formatter/css-formatter-client.tsx
+
+"use client";
+
+import { useState, ChangeEvent } from "react";
+import { css as beautify } from "js-beautify";
+
+export default function CssFormatterClient() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [minify, setMinify] = useState(false);
+  const [indentSize, setIndentSize] = useState(2);
+
+  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value);
+    setError(null);
+    setOutput("");
+  };
+
+  const runFormat = () => {
+    setError(null);
+    try {
+      const opts = minify
+        ? { indent_size: 0, max_preserve_newlines: 0 }
+        : { indent_size: indentSize };
+      const result = beautify(input, opts);
+      setOutput(result);
+    } catch {
+      setError("Error formatting CSS. Please check your input.");
+    }
+  };
+
+  const copyToClipboard = async () => {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      alert("✅ Output copied to clipboard!");
+    } catch {
+      alert("❌ Failed to copy output.");
+    }
+  };
+
+  const downloadOutput = () => {
+    if (!output) return;
+    const blob = new Blob([output], { type: "text/css" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "formatted.css";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section
+      id="css-formatter"
+      aria-labelledby="css-formatter-heading"
+      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+    >
+      <h1
+        id="css-formatter-heading"
+        className="text-4xl sm:text-5xl font-extrabold text-center mb-6 tracking-tight"
+      >
+        CSS Formatter & Minifier
+      </h1>
+      <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
+        Paste or type your CSS below to beautify or minify it. Choose indent
+        size or minify output—100% client-side, no signup required.
+      </p>
+
+      <label htmlFor="css-input" className="sr-only">
+        CSS Input
+      </label>
+      <textarea
+        id="css-input"
+        aria-label="CSS input"
+        value={input}
+        onChange={handleInputChange}
+        placeholder="body { margin: 0; }"
+        rows={10}
+        className="w-full p-4 border border-gray-300 rounded-lg font-mono text-sm resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+      />
+
+      <div className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
+        <div className="flex items-center space-x-4">
+          <label
+            htmlFor="indent-size-css"
+            className="flex items-center space-x-2"
+          >
+            <span className="text-sm font-medium text-gray-700">
+              Indent Size:
+            </span>
+            <select
+              id="indent-size-css"
+              value={indentSize}
+              onChange={(e) => setIndentSize(Number(e.target.value))}
+              disabled={minify}
+              className="border border-gray-300 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 transition"
+            >
+              <option value={0}>0</option>
+              <option value={2}>2</option>
+              <option value={4}>4</option>
+              <option value={8}>8</option>
+            </select>
+          </label>
+
+          <label htmlFor="minify-css" className="flex items-center space-x-2">
+            <input
+              id="minify-css"
+              type="checkbox"
+              checked={minify}
+              onChange={() => setMinify(!minify)}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+            />
+            <span className="text-sm text-gray-700">Minify</span>
+          </label>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={runFormat}
+            className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
+          >
+            Format / Minify
+          </button>
+          <button
+            type="button"
+            onClick={copyToClipboard}
+            disabled={!output}
+            className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 transition text-sm font-medium disabled:opacity-60"
+          >
+            Copy
+          </button>
+          <button
+            type="button"
+            onClick={downloadOutput}
+            disabled={!output}
+            className="px-4 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-700 transition text-sm font-medium disabled:opacity-60"
+          >
+            Download
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-6 p-4 bg-red-50 text-red-700 border border-red-200 rounded-md"
+        >
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
+
+      {output && (
+        <>
+          <label htmlFor="css-output" className="sr-only">
+            CSS Output
+          </label>
+          <textarea
+            id="css-output"
+            aria-label="Formatted CSS output"
+            value={output}
+            readOnly
+            rows={10}
+            className="mt-6 w-full p-4 border border-gray-300 rounded-lg font-mono text-sm bg-gray-50 resize-y focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          />
+        </>
+      )}
+    </section>
+  );
+}

--- a/app/tools/css-formatter/page.tsx
+++ b/app/tools/css-formatter/page.tsx
@@ -1,0 +1,59 @@
+// app/tools/css-formatter/page.tsx
+
+import CssFormatterClient from "./css-formatter-client";
+import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+
+export const metadata = {
+  metadataBase: new URL("https://gearizen.com"),
+  title: "CSS Formatter & Minifier",
+  description:
+    "Beautify or minify your CSS code instantly with Gearizen’s free client-side CSS Formatter & Minifier. Adjust indentation or strip whitespace—all without signup.",
+  keywords: [
+    "css formatter",
+    "css beautifier",
+    "css minifier",
+    "format css",
+    "beautify css",
+    "Gearizen tools",
+  ],
+  authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
+  robots: { index: true, follow: true },
+  alternates: { canonical: "https://gearizen.com/tools/css-formatter" },
+  openGraph: {
+    title: "CSS Formatter & Minifier | Gearizen",
+    description:
+      "Use Gearizen’s client-side CSS Formatter & Minifier to prettify or compress your stylesheets. Copy or download your result—100% free.",
+    url: "https://gearizen.com/tools/css-formatter",
+    siteName: "Gearizen",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/og-placeholder.svg",
+        width: 1200,
+        height: 630,
+        alt: "Gearizen CSS Formatter",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "CSS Formatter & Minifier | Gearizen",
+    description:
+      "Format or minify CSS completely offline with Gearizen’s free tool—no account needed, privacy-focused.",
+    creator: "@gearizen",
+    images: ["/og-placeholder.svg"],
+  },
+};
+
+export default function CssFormatterPage() {
+  return (
+    <>
+      <BreadcrumbJsonLd
+        pageTitle="CSS Formatter & Minifier"
+        pageUrl="https://gearizen.com/tools/css-formatter"
+      />
+      <CssFormatterClient />
+    </>
+  );
+}

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
   title: "Free Online Tools",
   description:
-    "Explore Gearizen’s 100% client-side toolbox: password & bcrypt generators, JSON tools, QR code creator, unit converter, image compressor & resizer, contrast checker, Base64 encoding, code & HTML formatters, regex tester, diff checker, timestamp converter, PDF and CSV utilities, SEO & OG tag generators, JWT decoder, and more—all free, no signup.",
+    "Explore Gearizen’s 100% client-side toolbox: password & bcrypt generators, JSON tools, QR code creator, unit converter, image compressor & resizer, contrast checker, Base64 encoding, code plus HTML and CSS formatters, regex tester, diff checker, timestamp converter, PDF and CSV utilities, SEO & OG tag generators, JWT decoder, and more—all free, no signup.",
   keywords: [
     "free online tools",
     "client-side tools",
@@ -30,6 +30,7 @@ export const metadata = {
     "PDF to Word",
     "CSV to JSON",
     "HTML formatter",
+    "CSS formatter",
     "HTML to PDF",
     "URL parser",
     "SEO meta tag generator",

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -37,6 +37,7 @@ import {
   Calculator,
   Ampersand,
   Palette,
+  Paintbrush,
   ListOrdered,
   Link2,
   Search,
@@ -167,6 +168,13 @@ const tools: Tool[] = [
     Icon: MessageSquare,
     title: "HTML Formatter",
     description: "Beautify or minify HTML code for readability or compactness.",
+  },
+  {
+    href: "/tools/css-formatter",
+    Icon: Paintbrush,
+    title: "CSS Formatter",
+    description:
+      "Beautify or minify CSS stylesheets instantly in your browser.",
   },
   {
     href: "/tools/seo-meta-tag-generator",


### PR DESCRIPTION
## Summary
- introduce a new CSS Formatter & Minifier tool
- list the new tool on the tools index page
- mention CSS formatter across metadata and keywords

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871a3785d848325b06862185715bc1a