### PR TITLE
Improve password and text tools

### DIFF
--- a/__tests__/generate-password.test.ts
+++ b/__tests__/generate-password.test.ts
@@ -43,4 +43,15 @@ describe("generatePassword", () => {
     expect(/[0-9]/.test(pwd)).toBe(true);
     expect(/[!@#$%^&*()\-_=+\[\]{}|;:',.<>?/`~]/.test(pwd)).toBe(true);
   });
+
+  test("excludes similar characters when requested", () => {
+    const pwd = generatePassword({
+      length: 20,
+      upper: true,
+      lower: true,
+      digits: true,
+      excludeSimilar: true,
+    });
+    expect(/[Il1O0]/.test(pwd)).toBe(false);
+  });
 });

--- a/app/tools/password-generator/password-generator-client.tsx
+++ b/app/tools/password-generator/password-generator-client.tsx
@@ -14,6 +14,7 @@ export default function PasswordGeneratorClient() {
   const [useLower, setUseLower] = useState(true);
   const [useDigits, setUseDigits] = useState(true);
   const [useSymbols, setUseSymbols] = useState(false);
+  const [excludeSimilar, setExcludeSimilar] = useState(false);
   const [password, setPassword] = useState("");
   const [copied, setCopied] = useState(false);
 
@@ -24,10 +25,11 @@ export default function PasswordGeneratorClient() {
       lower: useLower,
       digits: useDigits,
       symbols: useSymbols,
+      excludeSimilar,
     });
     setPassword(pwd);
     setCopied(false);
-  }, [length, useUpper, useLower, useDigits, useSymbols]);
+  }, [length, useUpper, useLower, useDigits, useSymbols, excludeSimilar]);
 
   useEffect(() => {
     generate();
@@ -55,6 +57,7 @@ export default function PasswordGeneratorClient() {
     useLower ? "--lower" : "",
     useDigits ? "--digits" : "",
     useSymbols ? "--symbols" : "",
+    excludeSimilar ? "--exclude-similar" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -177,6 +180,15 @@ export default function PasswordGeneratorClient() {
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
               <span className="text-gray-700 select-none">Symbols (!@#$%)</span>
+            </label>
+            <label className="flex items-center space-x-2 col-span-2">
+              <input
+                type="checkbox"
+                checked={excludeSimilar}
+                onChange={() => setExcludeSimilar((s) => !s)}
+                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+              />
+              <span className="text-gray-700 select-none">Exclude similar characters (1, l, I, O, 0)</span>
             </label>
           </div>
 

--- a/app/tools/text-counter/count-utils.test.ts
+++ b/app/tools/text-counter/count-utils.test.ts
@@ -1,4 +1,4 @@
-import { countWords, countCharacters } from "./count-utils";
+import { countWords, countCharacters, estimateReadingTime } from "./count-utils";
 
 test("counts words correctly", () => {
   expect(countWords("hello world")).toBe(2);
@@ -12,4 +12,9 @@ test("counts characters including unicode", () => {
   expect(countCharacters("🙂🙂")).toBe(2);
   expect(countCharacters("a b ")).toBe(4);
   expect(countCharacters("a b", { ignoreSpaces: true })).toBe(2);
+});
+
+test("estimates reading time in minutes", () => {
+  expect(estimateReadingTime("one two three four", 200)).toBe(1);
+  expect(estimateReadingTime("")).toBe(0);
 });

--- a/app/tools/text-counter/count-utils.ts
+++ b/app/tools/text-counter/count-utils.ts
@@ -15,3 +15,8 @@ export function countCharacters(
   const source = options.ignoreSpaces ? text.replace(/\s/gu, "") : text;
   return Array.from(source).length;
 }
+
+export function estimateReadingTime(text: string, wordsPerMinute = 200): number {
+  const words = countWords(text);
+  return wordsPerMinute > 0 ? Math.ceil(words / wordsPerMinute) : 0;
+}

--- a/app/tools/text-counter/text-counter-client.tsx
+++ b/app/tools/text-counter/text-counter-client.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { countWords, countCharacters } from "./count-utils";
+import { countWords, countCharacters, estimateReadingTime } from "./count-utils";
 
 export default function TextCounterClient() {
   const [text, setText] = useState("");
   const [ignoreSpaces, setIgnoreSpaces] = useState(false);
+  const [wpm, setWpm] = useState(200);
 
   const words = countWords(text);
   const chars = countCharacters(text, { ignoreSpaces });
+  const reading = estimateReadingTime(text, wpm);
 
   return (
     <section
@@ -41,9 +43,22 @@ export default function TextCounterClient() {
         />
         Ignore spaces in character count
       </label>
+      <label className="mt-4 flex items-center justify-center gap-2 text-sm">
+        <span>Words per minute:</span>
+        <input
+          type="number"
+          min={50}
+          max={500}
+          step={10}
+          value={wpm}
+          onChange={(e) => setWpm(Number(e.target.value))}
+          className="w-20 border border-gray-300 rounded-lg px-2 py-1 text-center focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+      </label>
       <div className="mt-6 flex justify-center gap-8 text-lg font-medium">
         <span>{words} words</span>
         <span>{chars} characters</span>
+        <span>{reading} min read</span>
       </div>
     </section>
   );

--- a/lib/generate-password.ts
+++ b/lib/generate-password.ts
@@ -4,12 +4,19 @@ export interface PasswordOptions {
   lower?: boolean;
   digits?: boolean;
   symbols?: boolean;
+  /** Exclude easily confused characters like 1, l, I, O and 0 */
+  excludeSimilar?: boolean;
 }
 
 const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const LOWER = "abcdefghijklmnopqrstuvwxyz";
 const DIGITS = "0123456789";
 const SYMBOLS = "!@#$%^&*()-_=+[]{}|;:',.<>?/`~";
+const SIMILAR = "Il1O0";
+
+function filterSet(source: string, exclude: boolean): string {
+  return exclude ? source.replace(new RegExp(`[${SIMILAR}]`, "g"), "") : source;
+}
 
 function randomIndex(max: number): number {
   const arr = new Uint32Array(1);
@@ -29,20 +36,21 @@ export function generatePassword(options: PasswordOptions): string {
   const length = Math.floor(options.length);
   if (length <= 0) return "";
 
+  const exclude = !!options.excludeSimilar;
   let pool = "";
-  if (options.upper) pool += UPPER;
-  if (options.lower) pool += LOWER;
-  if (options.digits) pool += DIGITS;
-  if (options.symbols) pool += SYMBOLS;
+  if (options.upper) pool += filterSet(UPPER, exclude);
+  if (options.lower) pool += filterSet(LOWER, exclude);
+  if (options.digits) pool += filterSet(DIGITS, exclude);
+  if (options.symbols) pool += filterSet(SYMBOLS, exclude);
   if (!pool) return "";
 
   const chars = Array.from({ length }, () => randomChar(pool));
 
   const required: string[] = [];
-  if (options.upper) required.push(randomChar(UPPER));
-  if (options.lower) required.push(randomChar(LOWER));
-  if (options.digits) required.push(randomChar(DIGITS));
-  if (options.symbols) required.push(randomChar(SYMBOLS));
+  if (options.upper) required.push(randomChar(filterSet(UPPER, exclude)));
+  if (options.lower) required.push(randomChar(filterSet(LOWER, exclude)));
+  if (options.digits) required.push(randomChar(filterSet(DIGITS, exclude)));
+  if (options.symbols) required.push(randomChar(filterSet(SYMBOLS, exclude)));
 
   const used = new Set<number>();
   required.forEach((ch) => {


### PR DESCRIPTION
## Summary
- extend password generator with exclude-similar option
- add reading time estimate to text counter
- cover new features with tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871ad4bfbd08325863cdd69c468c3ea