### PR TITLE
Improve password and JSON tools

### DIFF
--- a/__tests__/format-json.test.ts
+++ b/__tests__/format-json.test.ts
@@ -1,0 +1,33 @@
+import { formatJson } from '../lib/format-json';
+
+describe('formatJson', () => {
+  test('beautifies JSON', async () => {
+    const result = await formatJson('{"a":1}', {
+      mode: 'beautify',
+      indent: 2,
+      strict: true,
+      sortKeys: false,
+    });
+    expect(result).toBe('{' + '\n  "a": 1\n}');
+  });
+
+  test('minifies JSON', async () => {
+    const result = await formatJson('\n{ "a" : 1 } ', {
+      mode: 'minify',
+      indent: 2,
+      strict: true,
+      sortKeys: false,
+    });
+    expect(result).toBe('{"a":1}');
+  });
+
+  test('validates and sorts keys using JSON5 parser', async () => {
+    const result = await formatJson('{a:1,b:2}', {
+      mode: 'validate',
+      indent: 2,
+      strict: false,
+      sortKeys: true,
+    });
+    expect(result).toBe('Valid JSON');
+  });
+});

--- a/__tests__/generate-password.test.ts
+++ b/__tests__/generate-password.test.ts
@@ -43,4 +43,15 @@ describe("generatePassword", () => {
     expect(/[0-9]/.test(pwd)).toBe(true);
     expect(/[!@#$%^&*()\-_=+\[\]{}|;:',.<>?/`~]/.test(pwd)).toBe(true);
   });
+
+  test("excludes visually similar characters when requested", () => {
+    const pwd = generatePassword({
+      length: 32,
+      upper: true,
+      lower: true,
+      digits: true,
+      excludeSimilar: true,
+    });
+    expect(/[Il1O0]/.test(pwd)).toBe(false);
+  });
 });

--- a/app/tools/password-generator/password-generator-client.tsx
+++ b/app/tools/password-generator/password-generator-client.tsx
@@ -14,6 +14,7 @@ export default function PasswordGeneratorClient() {
   const [useLower, setUseLower] = useState(true);
   const [useDigits, setUseDigits] = useState(true);
   const [useSymbols, setUseSymbols] = useState(false);
+  const [excludeSimilar, setExcludeSimilar] = useState(false);
   const [password, setPassword] = useState("");
   const [copied, setCopied] = useState(false);
 
@@ -24,10 +25,11 @@ export default function PasswordGeneratorClient() {
       lower: useLower,
       digits: useDigits,
       symbols: useSymbols,
+      excludeSimilar,
     });
     setPassword(pwd);
     setCopied(false);
-  }, [length, useUpper, useLower, useDigits, useSymbols]);
+  }, [length, useUpper, useLower, useDigits, useSymbols, excludeSimilar]);
 
   useEffect(() => {
     generate();
@@ -55,6 +57,7 @@ export default function PasswordGeneratorClient() {
     useLower ? "--lower" : "",
     useDigits ? "--digits" : "",
     useSymbols ? "--symbols" : "",
+    excludeSimilar ? "--exclude-similar" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -177,6 +180,15 @@ export default function PasswordGeneratorClient() {
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
               <span className="text-gray-700 select-none">Symbols (!@#$%)</span>
+            </label>
+            <label className="flex items-center space-x-2 col-span-2">
+              <input
+                type="checkbox"
+                checked={excludeSimilar}
+                onChange={() => setExcludeSimilar((v) => !v)}
+                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+              />
+              <span className="text-gray-700 select-none">Exclude similar characters</span>
             </label>
           </div>
 

--- a/lib/format-json.ts
+++ b/lib/format-json.ts
@@ -1,0 +1,34 @@
+export type JsonMode = "beautify" | "minify" | "validate";
+export interface FormatJsonOptions {
+  mode: JsonMode;
+  indent: number;
+  strict: boolean;
+  sortKeys: boolean;
+}
+
+let json5Parser: { parse: (input: string) => unknown } | null = null;
+
+function sortObject(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortObject);
+  if (obj && typeof obj === "object") {
+    return Object.keys(obj)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortObject((obj as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return obj;
+}
+
+export async function formatJson(
+  src: string,
+  { mode, indent, strict, sortKeys }: FormatJsonOptions
+): Promise<string> {
+  const parser = strict ? JSON : (json5Parser ??= await import("json5"));
+  let parsed = parser.parse(src);
+  if (sortKeys) parsed = sortObject(parsed);
+  if (mode === "validate") return "Valid JSON";
+  const space = mode === "minify" ? 0 : indent;
+  return JSON.stringify(parsed, null, space);
+}

--- a/lib/generate-password.ts
+++ b/lib/generate-password.ts
@@ -4,6 +4,7 @@ export interface PasswordOptions {
   lower?: boolean;
   digits?: boolean;
   symbols?: boolean;
+  excludeSimilar?: boolean;
 }
 
 const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -11,10 +12,17 @@ const LOWER = "abcdefghijklmnopqrstuvwxyz";
 const DIGITS = "0123456789";
 const SYMBOLS = "!@#$%^&*()-_=+[]{}|;:',.<>?/`~";
 
+const SIMILAR = /[Il1O0]/g;
+
 function randomIndex(max: number): number {
   const arr = new Uint32Array(1);
-  globalThis.crypto.getRandomValues(arr);
-  return arr[0] % max;
+  const limit = Math.floor(0xffffffff / max) * max;
+  let rand;
+  do {
+    globalThis.crypto.getRandomValues(arr);
+    rand = arr[0];
+  } while (rand >= limit);
+  return rand % max;
 }
 
 function randomChar(set: string): string {
@@ -34,15 +42,24 @@ export function generatePassword(options: PasswordOptions): string {
   if (options.lower) pool += LOWER;
   if (options.digits) pool += DIGITS;
   if (options.symbols) pool += SYMBOLS;
+  if (options.excludeSimilar) {
+    pool = pool.replace(SIMILAR, "");
+  }
   if (!pool) return "";
 
   const chars = Array.from({ length }, () => randomChar(pool));
 
   const required: string[] = [];
-  if (options.upper) required.push(randomChar(UPPER));
-  if (options.lower) required.push(randomChar(LOWER));
-  if (options.digits) required.push(randomChar(DIGITS));
-  if (options.symbols) required.push(randomChar(SYMBOLS));
+  const upperSet = options.excludeSimilar ? UPPER.replace(SIMILAR, "") : UPPER;
+  const lowerSet = options.excludeSimilar ? LOWER.replace(SIMILAR, "") : LOWER;
+  const digitSet = options.excludeSimilar ? DIGITS.replace(SIMILAR, "") : DIGITS;
+  const symbolSet = options.excludeSimilar
+    ? SYMBOLS.replace(SIMILAR, "")
+    : SYMBOLS;
+  if (options.upper) required.push(randomChar(upperSet));
+  if (options.lower) required.push(randomChar(lowerSet));
+  if (options.digits) required.push(randomChar(digitSet));
+  if (options.symbols) required.push(randomChar(symbolSet));
 
   const used = new Set<number>();
   required.forEach((ch) => {


### PR DESCRIPTION
## Summary
- enhance password generator randomness and add exclude-similar option
- share JSON formatting logic via `formatJson` util
- refactor JSON formatter to use new util
- add unit tests for new utilities and options

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871ad4bfbd08325863cdd69c468c3ea