### PR TITLE
Fix build by using excludeSimilar variable

### DIFF
--- a/lib/generate-password.ts
+++ b/lib/generate-password.ts
@@ -36,21 +36,21 @@ export function generatePassword(options: PasswordOptions): string {
   const length = Math.floor(options.length);
   if (length <= 0) return "";
 
-  const exclude = !!options.excludeSimilar;
+  const excludeSimilar = !!options.excludeSimilar;
   let pool = "";
-  if (options.upper) pool += filterSet(UPPER, exclude);
-  if (options.lower) pool += filterSet(LOWER, exclude);
-  if (options.digits) pool += filterSet(DIGITS, exclude);
-  if (options.symbols) pool += filterSet(SYMBOLS, exclude);
+  if (options.upper) pool += filterSet(UPPER, excludeSimilar);
+  if (options.lower) pool += filterSet(LOWER, excludeSimilar);
+  if (options.digits) pool += filterSet(DIGITS, excludeSimilar);
+  if (options.symbols) pool += filterSet(SYMBOLS, excludeSimilar);
   if (!pool) return "";
 
   const chars = Array.from({ length }, () => randomChar(pool));
 
   const required: string[] = [];
-  if (options.upper) required.push(randomChar(filterSet(UPPER, exclude)));
-  if (options.lower) required.push(randomChar(filterSet(LOWER, exclude)));
-  if (options.digits) required.push(randomChar(filterSet(DIGITS, exclude)));
-  if (options.symbols) required.push(randomChar(filterSet(SYMBOLS, exclude)));
+  if (options.upper) required.push(randomChar(filterSet(UPPER, excludeSimilar)));
+  if (options.lower) required.push(randomChar(filterSet(LOWER, excludeSimilar)));
+  if (options.digits) required.push(randomChar(filterSet(DIGITS, excludeSimilar)));
+  if (options.symbols) required.push(randomChar(filterSet(SYMBOLS, excludeSimilar)));
 
   const used = new Set<number>();
   required.forEach((ch) => {


### PR DESCRIPTION
## Summary
- rename local `exclude` variable to `excludeSimilar` in `generate-password.ts`
- use the renamed variable throughout to prevent ESLint errors

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871b4db234483258f18e442f767f6ef