### PR TITLE
Enhance password generator features

### DIFF
--- a/__tests__/generate-password.test.ts
+++ b/__tests__/generate-password.test.ts
@@ -54,4 +54,28 @@ describe("generatePassword", () => {
     });
     expect(/[Il1O0]/.test(pwd)).toBe(false);
   });
+
+  test("generates using pattern", () => {
+    const pwd = generatePassword({
+      pattern: "Aa0$",
+      upper: true,
+      lower: true,
+      digits: true,
+      symbols: true,
+    });
+    expect(/[A-Z]/.test(pwd[0])).toBe(true);
+    expect(/[a-z]/.test(pwd[1])).toBe(true);
+    expect(/[0-9]/.test(pwd[2])).toBe(true);
+    expect(/[!@#$%^&*()\-_=+\[\]{}|;:',.<>?/`~]/.test(pwd[3])).toBe(true);
+  });
+
+  test("avoids consecutive repeats", () => {
+    const pwd = generatePassword({
+      length: 50,
+      upper: true,
+      lower: true,
+      avoidRepeats: true,
+    });
+    expect(/(.)\1/.test(pwd)).toBe(false);
+  });
 });

--- a/app/tools/password-generator/page.tsx
+++ b/app/tools/password-generator/page.tsx
@@ -2,6 +2,7 @@
 
 import PasswordGeneratorClient from "./password-generator-client";
 import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+import JsonLd from "@/app/components/JsonLd";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -46,9 +47,23 @@ export const metadata = {
   },
 };
 
-export default function PasswordGeneratorPage() {  return (
+export default function PasswordGeneratorPage() {
+  return (
     <>
-      <BreadcrumbJsonLd pageTitle="Strong Password Generator" pageUrl="https://gearizen.com/tools/password-generator" />
+      <BreadcrumbJsonLd
+        pageTitle="Strong Password Generator"
+        pageUrl="https://gearizen.com/tools/password-generator"
+      />
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "SoftwareApplication",
+          name: "Strong Password Generator",
+          operatingSystem: "any",
+          applicationCategory: "UtilitiesApplication",
+          offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+        }}
+      />
       <PasswordGeneratorClient />
     </>
   );

--- a/app/tools/password-generator/password-generator-client.tsx
+++ b/app/tools/password-generator/password-generator-client.tsx
@@ -6,8 +6,6 @@ import { useState, useEffect, useCallback, ChangeEvent } from "react";
 // Correct relative path to the shared password utility
 import { generatePassword } from "../../../lib/generate-password";
 
-
-
 export default function PasswordGeneratorClient() {
   const [length, setLength] = useState(16);
   const [useUpper, setUseUpper] = useState(true);
@@ -15,6 +13,8 @@ export default function PasswordGeneratorClient() {
   const [useDigits, setUseDigits] = useState(true);
   const [useSymbols, setUseSymbols] = useState(false);
   const [excludeSimilar, setExcludeSimilar] = useState(false);
+  const [pattern, setPattern] = useState("");
+  const [avoidRepeats, setAvoidRepeats] = useState(false);
   const [password, setPassword] = useState("");
   const [copied, setCopied] = useState(false);
 
@@ -26,10 +26,21 @@ export default function PasswordGeneratorClient() {
       digits: useDigits,
       symbols: useSymbols,
       excludeSimilar,
+      pattern: pattern || undefined,
+      avoidRepeats,
     });
     setPassword(pwd);
     setCopied(false);
-  }, [length, useUpper, useLower, useDigits, useSymbols, excludeSimilar]);
+  }, [
+    length,
+    useUpper,
+    useLower,
+    useDigits,
+    useSymbols,
+    excludeSimilar,
+    pattern,
+    avoidRepeats,
+  ]);
 
   useEffect(() => {
     generate();
@@ -58,6 +69,8 @@ export default function PasswordGeneratorClient() {
     useDigits ? "--digits" : "",
     useSymbols ? "--symbols" : "",
     excludeSimilar ? "--exclude-similar" : "",
+    pattern ? `--pattern ${pattern}` : "",
+    avoidRepeats ? "--avoid-repeats" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -116,6 +129,27 @@ export default function PasswordGeneratorClient() {
         className="space-y-8 max-w-2xl mx-auto"
         aria-label="Password options"
       >
+        {/* Pattern */}
+        <div>
+          <label
+            htmlFor="pattern"
+            className="block mb-2 font-medium text-gray-800"
+          >
+            Pattern (A a 0 $ ?)
+          </label>
+          <input
+            id="pattern"
+            type="text"
+            value={pattern}
+            onChange={(e) => setPattern(e.target.value)}
+            placeholder="e.g. Aa0$?"
+            className="input-base"
+          />
+          <p className="text-sm text-gray-500 mt-1">
+            Use A for uppercase, a for lowercase, 0 for numbers, $ for symbols,
+            ? for any.
+          </p>
+        </div>
         {/* Length Slider */}
         <div>
           <label
@@ -135,7 +169,13 @@ export default function PasswordGeneratorClient() {
             aria-valuemax={64}
             aria-valuenow={length}
             className="w-full"
+            disabled={pattern !== ""}
           />
+          {pattern && (
+            <p className="text-sm text-gray-500 mt-1">
+              Length is determined by pattern.
+            </p>
+          )}
         </div>
 
         {/* Character Sets */}
@@ -170,7 +210,6 @@ export default function PasswordGeneratorClient() {
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
               <span className="text-gray-700 select-none">Numbers (0–9)</span>
-
             </label>
             <label className="flex items-center space-x-2">
               <input
@@ -188,7 +227,20 @@ export default function PasswordGeneratorClient() {
                 onChange={() => setExcludeSimilar((s) => !s)}
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
-              <span className="text-gray-700 select-none">Exclude similar characters (1, l, I, O, 0)</span>
+              <span className="text-gray-700 select-none">
+                Exclude similar characters (1, l, I, O, 0)
+              </span>
+            </label>
+            <label className="flex items-center space-x-2 col-span-2">
+              <input
+                type="checkbox"
+                checked={avoidRepeats}
+                onChange={() => setAvoidRepeats((s) => !s)}
+                className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+              />
+              <span className="text-gray-700 select-none">
+                Avoid repeated characters
+              </span>
             </label>
           </div>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/(?!(marked)/)'
   ],
+  setupFiles: ['./jest.setup.ts'],
   globals: {
     'ts-jest': {
       useESM: true,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,6 @@
+if (typeof globalThis.crypto === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { webcrypto } = require('crypto');
+  // @ts-ignore
+  globalThis.crypto = webcrypto;
+}

--- a/lib/generate-password.ts
+++ b/lib/generate-password.ts
@@ -1,11 +1,15 @@
 export interface PasswordOptions {
-  length: number;
+  length?: number;
   upper?: boolean;
   lower?: boolean;
   digits?: boolean;
   symbols?: boolean;
   /** Exclude easily confused characters like 1, l, I, O and 0 */
   excludeSimilar?: boolean;
+  /** Pattern string using A (upper), a (lower), 0 (digit), $ (symbol) */
+  pattern?: string;
+  /** Avoid consecutive repeated characters */
+  avoidRepeats?: boolean;
 }
 
 const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -33,10 +37,48 @@ function randomChar(set: string): string {
  * Ensures at least one character from each selected set.
  */
 export function generatePassword(options: PasswordOptions): string {
-  const length = Math.floor(options.length);
+  const excludeSimilar = !!options.excludeSimilar;
+
+  // Pattern mode
+  if (options.pattern) {
+    const pattern = options.pattern;
+    const out: string[] = [];
+    for (const char of pattern) {
+      switch (char) {
+        case "A":
+          out.push(randomChar(filterSet(UPPER, excludeSimilar)));
+          break;
+        case "a":
+          out.push(randomChar(filterSet(LOWER, excludeSimilar)));
+          break;
+        case "0":
+          out.push(randomChar(filterSet(DIGITS, excludeSimilar)));
+          break;
+        case "$":
+          out.push(randomChar(filterSet(SYMBOLS, excludeSimilar)));
+          break;
+        case "?":
+        case "*":
+          out.push(
+            randomChar(
+              (options.upper ? filterSet(UPPER, excludeSimilar) : "") +
+                (options.lower ? filterSet(LOWER, excludeSimilar) : "") +
+                (options.digits ? filterSet(DIGITS, excludeSimilar) : "") +
+                (options.symbols ? filterSet(SYMBOLS, excludeSimilar) : "") ||
+                UPPER + LOWER + DIGITS,
+            ),
+          );
+          break;
+        default:
+          out.push(char);
+      }
+    }
+    return out.join("");
+  }
+
+  const length = Math.floor(options.length ?? 0);
   if (length <= 0) return "";
 
-  const excludeSimilar = !!options.excludeSimilar;
   let pool = "";
   if (options.upper) pool += filterSet(UPPER, excludeSimilar);
   if (options.lower) pool += filterSet(LOWER, excludeSimilar);
@@ -47,10 +89,14 @@ export function generatePassword(options: PasswordOptions): string {
   const chars = Array.from({ length }, () => randomChar(pool));
 
   const required: string[] = [];
-  if (options.upper) required.push(randomChar(filterSet(UPPER, excludeSimilar)));
-  if (options.lower) required.push(randomChar(filterSet(LOWER, excludeSimilar)));
-  if (options.digits) required.push(randomChar(filterSet(DIGITS, excludeSimilar)));
-  if (options.symbols) required.push(randomChar(filterSet(SYMBOLS, excludeSimilar)));
+  if (options.upper)
+    required.push(randomChar(filterSet(UPPER, excludeSimilar)));
+  if (options.lower)
+    required.push(randomChar(filterSet(LOWER, excludeSimilar)));
+  if (options.digits)
+    required.push(randomChar(filterSet(DIGITS, excludeSimilar)));
+  if (options.symbols)
+    required.push(randomChar(filterSet(SYMBOLS, excludeSimilar)));
 
   const used = new Set<number>();
   required.forEach((ch) => {
@@ -59,6 +105,16 @@ export function generatePassword(options: PasswordOptions): string {
     used.add(idx);
     chars[idx] = ch;
   });
+
+  if (options.avoidRepeats) {
+    for (let i = 1; i < chars.length; i++) {
+      if (chars[i] === chars[i - 1]) {
+        let next = randomChar(pool);
+        while (next === chars[i - 1]) next = randomChar(pool);
+        chars[i] = next;
+      }
+    }
+  }
 
   return chars.join("");
 }


### PR DESCRIPTION
## Summary
- support pattern-based passwords and avoid repeated characters
- expose new options in password generator UI
- add JSON-LD metadata for the tool page
- expand unit tests for new options
- add Jest setup for Web Crypto

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:e2e` *(fails: analytics and markdown-converter pages)*

------
https://chatgpt.com/codex/tasks/task_e_687248e34ea48325ba796d9f661355f1