### PR TITLE
Improve JSON Formatter with options and tests

### DIFF
--- a/__tests__/format-json.test.ts
+++ b/__tests__/format-json.test.ts
@@ -1,0 +1,44 @@
+import { formatJson } from '../lib/format-json';
+
+describe('formatJson', () => {
+  test('beautifies and sorts keys', async () => {
+    const { output, error } = await formatJson('{"b":1,"a":2}', {
+      mode: 'beautify',
+      indent: 2,
+      strict: true,
+      sortKeys: true,
+    });
+    expect(error).toBeNull();
+    expect(output).toBe('{' + '\n  "a": 2,\n  "b": 1\n}');
+  });
+
+  test('minifies JSON5 when not strict', async () => {
+    const { output } = await formatJson('{a:1}', {
+      mode: 'minify',
+      indent: 2,
+      strict: false,
+      sortKeys: false,
+    });
+    expect(output).toBe('{"a":1}');
+  });
+
+  test('validates JSON', async () => {
+    const { output } = await formatJson('{}', {
+      mode: 'validate',
+      indent: 2,
+      strict: true,
+      sortKeys: false,
+    });
+    expect(output).toBe('Valid JSON');
+  });
+
+  test('returns error on invalid JSON', async () => {
+    const { error } = await formatJson('{', {
+      mode: 'beautify',
+      indent: 2,
+      strict: true,
+      sortKeys: false,
+    });
+    expect(error).toBeTruthy();
+  });
+});

--- a/__tests__/json-formatter-client.test.tsx
+++ b/__tests__/json-formatter-client.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import JsonFormatterClient from '../app/tools/json-formatter/json-formatter-client';
+
+/** @jest-environment jsdom */
+
+describe('JsonFormatterClient', () => {
+  test('shows formatted output on input', async () => {
+    const user = userEvent.setup();
+    render(<JsonFormatterClient />);
+    const input = screen.getByLabelText('JSON input');
+    await user.type(input, '{"a":1}');
+    const output = await screen.findByLabelText('Formatted JSON output');
+    expect(output.innerHTML).toContain('"a"');
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -37,4 +37,20 @@
   .card {
     @apply bg-white border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-shadow;
   }
+
+  .json-key {
+    @apply text-purple-700;
+  }
+  .json-string {
+    @apply text-green-700;
+  }
+  .json-number {
+    @apply text-blue-700;
+  }
+  .json-boolean {
+    @apply text-red-700;
+  }
+  .json-null {
+    @apply text-gray-500;
+  }
 }

--- a/lib/format-json.ts
+++ b/lib/format-json.ts
@@ -1,0 +1,52 @@
+import jsonlint from 'jsonlint-mod';
+let json5: typeof import('json5') | null = null;
+
+export type JsonMode = 'beautify' | 'minify' | 'validate';
+
+export interface FormatJsonOptions {
+  mode: JsonMode;
+  indent: number;
+  strict: boolean;
+  sortKeys: boolean;
+}
+
+function sortObject(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortObject);
+  if (obj && typeof obj === 'object') {
+    return Object.keys(obj)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortObject((obj as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return obj;
+}
+
+async function parse(src: string, strict: boolean) {
+  if (strict) return jsonlint.parse(src);
+  if (!json5) {
+    json5 = await import('json5');
+  }
+  return json5.parse(src);
+}
+
+export async function formatJson(
+  src: string,
+  { mode, indent, strict, sortKeys }: FormatJsonOptions
+): Promise<{ output: string; error: string | null }> {
+  try {
+    let obj = await parse(src, strict);
+    if (sortKeys) obj = sortObject(obj);
+    if (mode === 'validate') {
+      return { output: 'Valid JSON', error: null };
+    }
+    const space = mode === 'minify' ? 0 : indent;
+    return { output: JSON.stringify(obj, null, space), error: null };
+  } catch (e: unknown) {
+    return {
+      output: '',
+      error: e instanceof Error ? e.message : 'Invalid JSON',
+    };
+  }
+}

--- a/lib/highlight-json.ts
+++ b/lib/highlight-json.ts
@@ -1,0 +1,13 @@
+export function highlightJson(json: string): string {
+  const esc = json
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  return esc
+    .replace(/"(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"(?=\s*:)/g, '<span class="json-key">$&</span>')
+    .replace(/"(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"/g, '<span class="json-string">$&</span>')
+    .replace(/\b(true|false)\b/g, '<span class="json-boolean">$1</span>')
+    .replace(/\bnull\b/g, '<span class="json-null">null</span>')
+    .replace(/\b(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b/g, '<span class="json-number">$1</span>');
+}


### PR DESCRIPTION
## Summary
- add syntax highlighting styles
- implement JSON formatting utilities
- enhance JSON Formatter client with wrapping, formatting button, and highlighting
- add unit and UI tests for JSON formatting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687265c38af483259aade01c2047573c