### PR TITLE
Refactor JSON formatter UX

### DIFF
--- a/__tests__/highlight-json.test.ts
+++ b/__tests__/highlight-json.test.ts
@@ -1,0 +1,14 @@
+import { highlightJson } from '../lib/highlight-json';
+
+describe('highlightJson', () => {
+  test('wraps keys and numbers with span tags', () => {
+    const html = highlightJson('{"a":1}');
+    expect(html).toContain('json-key');
+    expect(html).toContain('json-number');
+  });
+
+  test('escapes html characters', () => {
+    const html = highlightJson('{"a":"<b>"}');
+    expect(html).toContain('&lt;b&gt;');
+  });
+});

--- a/__tests__/json-formatter-client.test.tsx
+++ b/__tests__/json-formatter-client.test.tsx
@@ -13,4 +13,19 @@ describe('JsonFormatterClient', () => {
     const output = await screen.findByLabelText('Formatted JSON output');
     expect(output.innerHTML).toContain('"a"');
   });
+
+  test('displays error message on invalid JSON', async () => {
+    const user = userEvent.setup();
+    render(<JsonFormatterClient />);
+    const input = screen.getByLabelText('JSON input');
+    await user.type(input, '{');
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/invalid/i);
+  });
+
+  test('copy button disabled without output', () => {
+    render(<JsonFormatterClient />);
+    const copyBtn = screen.getByRole('button', { name: 'Copy' });
+    expect(copyBtn).toBeDisabled();
+  });
 });

--- a/e2e/json-formatter.spec.ts
+++ b/e2e/json-formatter.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+// basic e2e check for json formatter
+
+test('formats JSON and shows output', async ({ page }) => {
+  await page.goto('/tools/json-formatter');
+  await page.getByLabel('JSON input').fill('{"x":1}');
+  await page.getByRole('button', { name: 'Format' }).click();
+  await expect(page.getByLabel('Formatted JSON output')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- refine JSON formatter page layout and add output options
- keep buttons responsive and upgrade styling
- add syntax highlight toggle and custom filename
- cover formatter behavior with new unit and UI tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68726a321020832591711edc1c306ffb