### PR TITLE
Refactor Navbar to Header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@
 
 import "./globals.css";
 import { ReactNode } from "react";
-import Navbar from "@/components/Navbar";
+import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import ToolProviders from "@/components/ToolProviders";
 import AnalyticsLoader from "./components/AnalyticsLoader";
@@ -77,6 +77,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preload" href="/favicon.png" as="image" type="image/png" />
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
@@ -105,7 +106,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           </a>
 
           {/* Primary navigation */}
-          <Navbar />
+          <Header />
 
           {/* Main content area */}
           <main

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,4 @@
-// components/Navbar.tsx
+// components/Header.tsx
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
@@ -15,7 +15,10 @@ const navLinks = [
   { href: "/privacy", label: "Privacy" },
 ];
 
-export default function Navbar() {
+/**
+ * Global site header with responsive navigation.
+ */
+export default function Header() {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -74,31 +77,31 @@ export default function Navbar() {
         </Link>
 
         {/* Desktop navigation */}
-        <nav
-          aria-label="Primary"
-          className="hidden md:flex items-center space-x-6"
-        >
-          {navLinks.map(({ href, label }) => {
-            const active = pathname === href;
-            return (
-              <Link
-                key={href}
-                href={href}
-                aria-current={active ? "page" : undefined}
-                className={`
-                  relative text-sm font-medium transition-colors
-                  focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2
-                  ${
-                    active
-                      ? "text-indigo-600 after:absolute after:-bottom-1 after:left-0 after:w-full after:h-0.5 after:bg-indigo-600"
-                      : "text-gray-700 hover:text-gray-900"
-                  }
-                `}
-              >
-                {label}
-              </Link>
-            );
-          })}
+        <nav aria-label="Primary" className="hidden md:block">
+          <ul className="flex items-center space-x-6">
+            {navLinks.map(({ href, label }) => {
+              const active = pathname === href;
+              return (
+                <li key={href} className="list-none">
+                  <Link
+                    href={href}
+                    aria-current={active ? "page" : undefined}
+                    className={`
+                      relative text-sm font-medium transition-colors
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2
+                      ${
+                        active
+                          ? "text-indigo-600 after:absolute after:-bottom-1 after:left-0 after:w-full after:h-0.5 after:bg-indigo-600"
+                          : "text-gray-700 hover:text-gray-900"
+                      }
+                    `}
+                  >
+                    {label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
         </nav>
 
         {/* Mobile menu toggle */}


### PR DESCRIPTION
## Summary
- rename `Navbar` to `Header`
- switch desktop nav to use `<ul>`/`<li>` for better semantics
- preload the logo in `layout.tsx`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727d09e430832599ccff540043edfe