### PR TITLE
Refactor tools listing with semantic layout and reusable cards

### DIFF
--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -2,6 +2,8 @@
 
 import ToolsClient from "./tools-client";
 import BreadcrumbJsonLd from "@/app/components/BreadcrumbJsonLd";
+import JsonLd from "@/app/components/JsonLd";
+import { tools } from "@/lib/tools";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -69,6 +71,26 @@ export const metadata = {
   },
 };
 
+const toolsJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "Free Online Tools",
+  url: "https://gearizen.com/tools",
+  description: metadata.description,
+  mainEntity: {
+    "@type": "ItemList",
+    itemListElement: tools.map((t, i) => ({
+      "@type": "SoftwareApplication",
+      name: t.title,
+      operatingSystem: "any",
+      applicationCategory: "UtilitiesApplication",
+      offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+      url: `https://gearizen.com${t.href}`,
+      position: i + 1,
+    })),
+  },
+};
+
 export default function ToolsPage() {
   return (
     <>
@@ -76,6 +98,7 @@ export default function ToolsPage() {
         pageTitle="Free Online Tools"
         pageUrl="https://gearizen.com/tools"
       />
+      <JsonLd data={toolsJsonLd} />
       <ToolsClient />
     </>
   );

--- a/app/tools/tools-client.tsx
+++ b/app/tools/tools-client.tsx
@@ -2,313 +2,10 @@
 
 "use client";
 
-import CardLink from "@/components/CardLink";
 import { useState } from "react";
-import {
-  Key,
-  Code,
-  QrCode,
-  ArrowRightLeft,
-  ImageIcon,
-  Eye,
-  Paperclip,
-  Cpu,
-  FileCode,
-  Scissors,
-  CalendarCheck2,
-  FileText,
-  FileKey,
-  File,
-  FilePlus,
-  FileDown,
-  FileArchive,
-  MessageSquare,
-  Tag,
-  Globe,
-  Shield,
-  ImagePlus,
-  BookOpen,
-  Fingerprint,
-  AlignLeft,
-  Type,
-  Link as LinkIcon,
-  Hash,
-  Braces,
-  Calculator,
-  Ampersand,
-  RotateCcw,
-  Palette,
-  Paintbrush,
-  ListOrdered,
-  Link2,
-  Search,
-  Radio,
-} from "lucide-react";
-
-interface Tool {
-  href: string;
-  Icon: React.FC<React.SVGProps<SVGSVGElement>>;
-  title: string;
-  description: string;
-}
-
-const tools: Tool[] = [
-  {
-    href: "/tools/password-generator",
-    Icon: Key,
-    title: "Password Generator",
-    description:
-      "Generate strong, secure passwords with customizable length and character sets.",
-  },
-  {
-    href: "/tools/json-formatter",
-    Icon: Code,
-    title: "JSON Formatter",
-    description: "Validate, beautify, or minify JSON entirely in your browser.",
-  },
-  {
-    href: "/tools/qr-code-generator",
-    Icon: QrCode,
-    title: "QR Code Generator",
-    description: "Produce QR codes for URLs, text, contacts, and more.",
-  },
-  {
-    href: "/tools/unit-converter",
-    Icon: ArrowRightLeft,
-    title: "Unit Converter",
-    description:
-      "Convert between metric and imperial units: length, weight, volume, and more.",
-  },
-  {
-    href: "/tools/image-compressor",
-    Icon: ImageIcon,
-    title: "Image Compressor",
-    description:
-      "Reduce JPEG or PNG file sizes while preserving visual quality.",
-  },
-  {
-    href: "/tools/color-contrast-checker",
-    Icon: Eye,
-    title: "Contrast Checker",
-    description: "Ensure your text meets WCAG accessibility contrast ratios.",
-  },
-  {
-    href: "/tools/color-converter",
-    Icon: Palette,
-    title: "Color Converter",
-    description: "Convert colors between HEX, RGB and HSL with preview.",
-  },
-  {
-    href: "/tools/color-palette-generator",
-    Icon: Palette,
-    title: "Color Palette Generator",
-    description: "Create harmonious color schemes from any base color.",
-  },
-  {
-    href: "/tools/base64-encoder-decoder",
-    Icon: Paperclip,
-    title: "Base64 Encoder/Decoder",
-    description: "Encode or decode text and files to Base64 format rapidly.",
-  },
-  {
-    href: "/tools/code-minifier",
-    Icon: Cpu,
-    title: "Code Minifier",
-    description: "Minify HTML, CSS, and JavaScript to boost page load speeds.",
-  },
-  {
-    href: "/tools/regex-tester",
-    Icon: Scissors,
-    title: "Regex Tester",
-    description:
-      "Build and debug regular expressions with real-time match highlighting.",
-  },
-  {
-    href: "/tools/text-diff",
-    Icon: FileText,
-    title: "Text Diff Checker",
-    description:
-      "Compare two blocks of text and highlight additions, deletions, and changes.",
-  },
-  {
-    href: "/tools/unix-timestamp-converter",
-    Icon: CalendarCheck2,
-    title: "Timestamp Converter",
-    description: "Convert UNIX timestamps to human-readable dates and back.",
-  },
-  {
-    href: "/tools/pdf-compressor",
-    Icon: FileArchive,
-    title: "PDF Compressor",
-    description:
-      "Compress PDFs client-side to reduce file size without losing clarity.",
-  },
-  {
-    href: "/tools/pdf-to-word",
-    Icon: FilePlus,
-    title: "PDF → Word Converter",
-    description:
-      "Extract text from PDFs and download as Word-compatible DOC files.",
-  },
-  {
-    href: "/tools/image-resizer",
-    Icon: FileDown,
-    title: "Image Resizer",
-    description:
-      "Resize images, maintain or override aspect ratio, then download.",
-  },
-  {
-    href: "/tools/csv-to-json",
-    Icon: File,
-    title: "CSV → JSON Converter",
-    description:
-      "Transform CSV data into JSON arrays quickly, entirely in-browser.",
-  },
-  {
-    href: "/tools/html-to-pdf",
-    Icon: Globe,
-    title: "HTML → PDF Converter",
-    description:
-      "Render HTML pages as PDFs completely client-side, no server needed.",
-  },
-  {
-    href: "/tools/html-formatter",
-    Icon: MessageSquare,
-    title: "HTML Formatter",
-    description: "Beautify or minify HTML code for readability or compactness.",
-  },
-  {
-    href: "/tools/css-formatter",
-    Icon: Paintbrush,
-    title: "CSS Formatter",
-    description:
-      "Beautify or minify CSS stylesheets instantly in your browser.",
-  },
-  {
-    href: "/tools/seo-meta-tag-generator",
-    Icon: Tag,
-    title: "SEO Meta Tag Generator",
-    description:
-      "Generate optimized `<title>`, `<meta>` and social tags for any page.",
-  },
-  {
-    href: "/tools/jwt-decoder",
-    Icon: Shield,
-    title: "JWT Decoder",
-    description:
-      "Decode and inspect JWT header, payload & signature client-side.",
-  },
-  {
-    href: "/tools/bcrypt-generator",
-    Icon: FileKey,
-    title: "bcrypt Hash Generator",
-    description:
-      "Generate bcrypt hashes for passwords with adjustable salt rounds.",
-  },
-  {
-    href: "/tools/image-to-base64",
-    Icon: ImagePlus,
-    title: "Image → Base64",
-    description: "Turn images into Base64 data URIs in-browser.",
-  },
-  {
-    href: "/tools/markdown-converter",
-    Icon: BookOpen,
-    title: "Markdown Converter",
-    description: "Edit Markdown, preview live, and copy clean HTML.",
-  },
-  {
-    href: "/tools/uuid-generator",
-    Icon: Fingerprint,
-    title: "UUID Generator",
-    description: "Create RFC4122 UUIDs instantly.",
-  },
-  {
-    href: "/tools/lorem-ipsum-generator",
-    Icon: AlignLeft,
-    title: "Lorem Ipsum Generator",
-    description: "Generate placeholder text paragraphs.",
-  },
-  {
-    href: "/tools/text-counter",
-    Icon: Type,
-    title: "Word & Character Counter",
-    description: "Count words and characters in any text.",
-  },
-  {
-    href: "/tools/text-sorter",
-    Icon: ListOrdered,
-    title: "Text Sorter",
-    description: "Sort lines alphabetically and remove duplicates.",
-  },
-  {
-    href: "/tools/url-encoder-decoder",
-    Icon: LinkIcon,
-    title: "URL Encoder/Decoder",
-    description: "Encode or decode URLs and query strings.",
-  },
-  {
-    href: "/tools/html-entity-encoder-decoder",
-    Icon: Ampersand,
-    title: "HTML Entity Encoder/Decoder",
-    description: "Convert characters to HTML entities or decode them back.",
-  },
-  {
-    href: "/tools/slug-generator",
-    Icon: Link2,
-    title: "URL Slug Generator",
-    description: "Slugify text into SEO-friendly URLs quickly.",
-  },
-  {
-    href: "/tools/url-parser",
-    Icon: Search,
-    title: "URL Parser",
-    description:
-      "Break down URLs to view protocol, host, path and query parameters.",
-  },
-  {
-    href: "/tools/base-converter",
-    Icon: Calculator,
-    title: "Number Base Converter",
-    description: "Convert numbers between binary, decimal, hex and more.",
-  },
-  {
-    href: "/tools/sha-hash-generator",
-    Icon: Hash,
-    title: "Hash Generator",
-    description: "Create SHA-256, SHA-1 or MD5 hashes for any text.",
-  },
-  {
-    href: "/tools/yaml-json-converter",
-    Icon: Braces,
-    title: "YAML ⇄ JSON Converter",
-    description: "Convert YAML to JSON or JSON to YAML in-browser.",
-  },
-  {
-    href: "/tools/text-case-converter",
-    Icon: Type,
-    title: "Text Case Converter",
-    description: "Convert text between upper, lower, camel, snake and more.",
-  },
-  {
-    href: "/tools/caesar-cipher",
-    Icon: RotateCcw,
-    title: "Caesar Cipher",
-    description: "Encrypt or decrypt text with a custom shift value.",
-  },
-  {
-    href: "/tools/morse-code-converter",
-    Icon: Radio,
-    title: "Morse Code Converter",
-    description: "Translate text to and from Morse code instantly.",
-  },
-  {
-    href: "/tools/xml-formatter",
-    Icon: FileCode,
-    title: "XML Formatter",
-    description: "Beautify or minify XML documents instantly.",
-  },
-];
+import Input from "@/components/Input";
+import ToolCard from "@/components/ToolCard";
+import { tools } from "@/lib/tools";
 
 export default function ToolsClient() {
   const [search, setSearch] = useState("");
@@ -319,8 +16,8 @@ export default function ToolsClient() {
   );
 
   return (
-    <section
-      id="all-tools"
+    <main
+      id="main-content"
       aria-labelledby="all-tools-heading"
       className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900 space-y-12"
     >
@@ -337,17 +34,17 @@ export default function ToolsClient() {
       </header>
 
       {/* Search */}
-      <div className="max-w-md mx-auto">
+      <div className="max-w-md mx-auto" role="search">
         <label htmlFor="tool-search" className="sr-only">
           Search tools
         </label>
-        <input
+        <Input
           id="tool-search"
           type="search"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search tools..."
-          className="w-full border border-gray-300 rounded-lg px-4 py-2 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          aria-label="Search tools"
         />
       </div>
 
@@ -356,29 +53,14 @@ export default function ToolsClient() {
         <h2 id="tools-heading" className="sr-only">
           All Tools
         </h2>
-        <ul className="grid gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-          {filteredTools.map(({ href, Icon, title, description }) => (
-            <li key={href} className="list-none">
-              <CardLink
-                href={href}
-                aria-label={`Navigate to ${title}`}
-                className="group flex flex-col h-full"
-              >
-                <Icon
-                  className="w-10 h-10 text-indigo-600 mx-auto mb-4"
-                  aria-hidden="true"
-                />
-                <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-indigo-600 transition-colors">
-                  {title}
-                </h3>
-                <p className="text-gray-600 text-center flex-grow">
-                  {description}
-                </p>
-              </CardLink>
+        <ul className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {filteredTools.map((tool) => (
+            <li key={tool.href} className="list-none">
+              <ToolCard {...tool} />
             </li>
           ))}
         </ul>
       </section>
-    </section>
+    </main>
   );
 }

--- a/components/ToolCard.tsx
+++ b/components/ToolCard.tsx
@@ -1,0 +1,53 @@
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { LucideProps } from "lucide-react";
+import { useMemo } from "react";
+
+export interface ToolCardProps {
+  href: string;
+  icon: string;
+  title: string;
+  description: string;
+  className?: string;
+}
+
+const iconCache: Record<string, React.ComponentType<LucideProps>> = {};
+
+function getIcon(name: string) {
+  if (!iconCache[name]) {
+    iconCache[name] = dynamic<LucideProps>(
+      () =>
+        import("lucide-react").then((m) => ({
+          default: (
+            m as unknown as Record<string, React.ComponentType<LucideProps>>
+          )[name],
+        })),
+      { ssr: false },
+    );
+  }
+  return iconCache[name];
+}
+
+export default function ToolCard({
+  href,
+  icon,
+  title,
+  description,
+  className = "",
+}: ToolCardProps) {
+  const Icon = useMemo(() => getIcon(icon), [icon]);
+
+  return (
+    <Link
+      href={href}
+      aria-label={`Navigate to ${title}`}
+      className={`card flex flex-col h-full items-center text-center focus-visible:ring-2 focus-visible:ring-indigo-500 ${className}`}
+    >
+      <Icon className="w-10 h-10 text-indigo-600 mb-4" aria-hidden="true" />
+      <h3 className="text-xl font-semibold mb-2 group-hover:text-indigo-600 transition-colors">
+        {title}
+      </h3>
+      <p className="text-gray-600 break-words flex-grow">{description}</p>
+    </Link>
+  );
+}

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -1,0 +1,264 @@
+export interface Tool {
+  href: string;
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export const tools: Tool[] = [
+  {
+    href: "/tools/password-generator",
+    icon: "Key",
+    title: "Password Generator",
+    description:
+      "Generate strong, secure passwords with customizable length and character sets.",
+  },
+  {
+    href: "/tools/json-formatter",
+    icon: "Code",
+    title: "JSON Formatter",
+    description: "Validate, beautify, or minify JSON entirely in your browser.",
+  },
+  {
+    href: "/tools/qr-code-generator",
+    icon: "QrCode",
+    title: "QR Code Generator",
+    description: "Produce QR codes for URLs, text, contacts, and more.",
+  },
+  {
+    href: "/tools/unit-converter",
+    icon: "ArrowRightLeft",
+    title: "Unit Converter",
+    description:
+      "Convert between metric and imperial units: length, weight, volume, and more.",
+  },
+  {
+    href: "/tools/image-compressor",
+    icon: "ImageIcon",
+    title: "Image Compressor",
+    description:
+      "Reduce JPEG or PNG file sizes while preserving visual quality.",
+  },
+  {
+    href: "/tools/color-contrast-checker",
+    icon: "Eye",
+    title: "Contrast Checker",
+    description: "Ensure your text meets WCAG accessibility contrast ratios.",
+  },
+  {
+    href: "/tools/color-converter",
+    icon: "Palette",
+    title: "Color Converter",
+    description: "Convert colors between HEX, RGB and HSL with preview.",
+  },
+  {
+    href: "/tools/color-palette-generator",
+    icon: "Palette",
+    title: "Color Palette Generator",
+    description: "Create harmonious color schemes from any base color.",
+  },
+  {
+    href: "/tools/base64-encoder-decoder",
+    icon: "Paperclip",
+    title: "Base64 Encoder/Decoder",
+    description: "Encode or decode text and files to Base64 format rapidly.",
+  },
+  {
+    href: "/tools/code-minifier",
+    icon: "Cpu",
+    title: "Code Minifier",
+    description: "Minify HTML, CSS, and JavaScript to boost page load speeds.",
+  },
+  {
+    href: "/tools/regex-tester",
+    icon: "Scissors",
+    title: "Regex Tester",
+    description:
+      "Build and debug regular expressions with real-time match highlighting.",
+  },
+  {
+    href: "/tools/text-diff",
+    icon: "FileText",
+    title: "Text Diff Checker",
+    description:
+      "Compare two blocks of text and highlight additions, deletions, and changes.",
+  },
+  {
+    href: "/tools/unix-timestamp-converter",
+    icon: "CalendarCheck2",
+    title: "Timestamp Converter",
+    description: "Convert UNIX timestamps to human-readable dates and back.",
+  },
+  {
+    href: "/tools/pdf-compressor",
+    icon: "FileArchive",
+    title: "PDF Compressor",
+    description:
+      "Compress PDFs client-side to reduce file size without losing clarity.",
+  },
+  {
+    href: "/tools/pdf-to-word",
+    icon: "FilePlus",
+    title: "PDF → Word Converter",
+    description:
+      "Extract text from PDFs and download as Word-compatible DOC files.",
+  },
+  {
+    href: "/tools/image-resizer",
+    icon: "FileDown",
+    title: "Image Resizer",
+    description:
+      "Resize images, maintain or override aspect ratio, then download.",
+  },
+  {
+    href: "/tools/csv-to-json",
+    icon: "File",
+    title: "CSV → JSON Converter",
+    description:
+      "Transform CSV data into JSON arrays quickly, entirely in-browser.",
+  },
+  {
+    href: "/tools/html-to-pdf",
+    icon: "Globe",
+    title: "HTML → PDF Converter",
+    description:
+      "Render HTML pages as PDFs completely client-side, no server needed.",
+  },
+  {
+    href: "/tools/html-formatter",
+    icon: "MessageSquare",
+    title: "HTML Formatter",
+    description: "Beautify or minify HTML code for readability or compactness.",
+  },
+  {
+    href: "/tools/css-formatter",
+    icon: "Paintbrush",
+    title: "CSS Formatter",
+    description:
+      "Beautify or minify CSS stylesheets instantly in your browser.",
+  },
+  {
+    href: "/tools/seo-meta-tag-generator",
+    icon: "Tag",
+    title: "SEO Meta Tag Generator",
+    description:
+      "Generate optimized `<title>`, `<meta>` and social tags for any page.",
+  },
+  {
+    href: "/tools/jwt-decoder",
+    icon: "Shield",
+    title: "JWT Decoder",
+    description:
+      "Decode and inspect JWT header, payload & signature client-side.",
+  },
+  {
+    href: "/tools/bcrypt-generator",
+    icon: "FileKey",
+    title: "bcrypt Hash Generator",
+    description:
+      "Generate bcrypt hashes for passwords with adjustable salt rounds.",
+  },
+  {
+    href: "/tools/image-to-base64",
+    icon: "ImagePlus",
+    title: "Image → Base64",
+    description: "Turn images into Base64 data URIs in-browser.",
+  },
+  {
+    href: "/tools/markdown-converter",
+    icon: "BookOpen",
+    title: "Markdown Converter",
+    description: "Edit Markdown, preview live, and copy clean HTML.",
+  },
+  {
+    href: "/tools/uuid-generator",
+    icon: "Fingerprint",
+    title: "UUID Generator",
+    description: "Create RFC4122 UUIDs instantly.",
+  },
+  {
+    href: "/tools/lorem-ipsum-generator",
+    icon: "AlignLeft",
+    title: "Lorem Ipsum Generator",
+    description: "Generate placeholder text paragraphs.",
+  },
+  {
+    href: "/tools/text-counter",
+    icon: "Type",
+    title: "Word & Character Counter",
+    description: "Count words and characters in any text.",
+  },
+  {
+    href: "/tools/text-sorter",
+    icon: "ListOrdered",
+    title: "Text Sorter",
+    description: "Sort lines alphabetically and remove duplicates.",
+  },
+  {
+    href: "/tools/url-encoder-decoder",
+    icon: "LinkIcon",
+    title: "URL Encoder/Decoder",
+    description: "Encode or decode URLs and query strings.",
+  },
+  {
+    href: "/tools/html-entity-encoder-decoder",
+    icon: "Ampersand",
+    title: "HTML Entity Encoder/Decoder",
+    description: "Convert characters to HTML entities or decode them back.",
+  },
+  {
+    href: "/tools/slug-generator",
+    icon: "Link2",
+    title: "URL Slug Generator",
+    description: "Slugify text into SEO-friendly URLs quickly.",
+  },
+  {
+    href: "/tools/url-parser",
+    icon: "Search",
+    title: "URL Parser",
+    description:
+      "Break down URLs to view protocol, host, path and query parameters.",
+  },
+  {
+    href: "/tools/base-converter",
+    icon: "Calculator",
+    title: "Number Base Converter",
+    description: "Convert numbers between binary, decimal, hex and more.",
+  },
+  {
+    href: "/tools/sha-hash-generator",
+    icon: "Hash",
+    title: "Hash Generator",
+    description: "Create SHA-256, SHA-1 or MD5 hashes for any text.",
+  },
+  {
+    href: "/tools/yaml-json-converter",
+    icon: "Braces",
+    title: "YAML ⇄ JSON Converter",
+    description: "Convert YAML to JSON or JSON to YAML in-browser.",
+  },
+  {
+    href: "/tools/text-case-converter",
+    icon: "Type",
+    title: "Text Case Converter",
+    description: "Convert text between upper, lower, camel, snake and more.",
+  },
+  {
+    href: "/tools/caesar-cipher",
+    icon: "RotateCcw",
+    title: "Caesar Cipher",
+    description: "Encrypt or decrypt text with a custom shift value.",
+  },
+  {
+    href: "/tools/morse-code-converter",
+    icon: "Radio",
+    title: "Morse Code Converter",
+    description: "Translate text to and from Morse code instantly.",
+  },
+  {
+    href: "/tools/xml-formatter",
+    icon: "FileCode",
+    title: "XML Formatter",
+    description: "Beautify or minify XML documents instantly.",
+  },
+];


### PR DESCRIPTION
## Summary
- extract tool metadata to `lib/tools.ts`
- create `ToolCard` component with lazy-loaded icons
- refactor `tools-client` to use semantic `<main>` layout and accessible search
- inject structured data into tools page for SEO

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727d86e3608325b76ac1d14dfbffcb