### PR TITLE
Improve password generator

### DIFF
--- a/__tests__/generate-password.test.ts
+++ b/__tests__/generate-password.test.ts
@@ -69,15 +69,20 @@ describe("generatePassword", () => {
     expect(/[!@#$%^&*()\-_=+\[\]{}|;:',.<>?/`~]/.test(pwd[3])).toBe(true);
   });
 
-  test("pattern '?' respects selected sets", () => {
+  test("pattern overrides length and other settings", () => {
     const pwd = generatePassword({
-      pattern: "???",
-      upper: true,
-      digits: true,
+      pattern: "Aa0",
+      length: 20,
+      upper: false,
       lower: false,
+      digits: false,
       symbols: false,
+      minUpper: 5,
     });
-    expect(/^[A-Z0-9]{3}$/.test(pwd)).toBe(true);
+    expect(pwd).toHaveLength(3);
+    expect(/[A-Z]/.test(pwd[0])).toBe(true);
+    expect(/[a-z]/.test(pwd[1])).toBe(true);
+    expect(/[0-9]/.test(pwd[2])).toBe(true);
   });
 
   test("avoids consecutive repeats", () => {

--- a/__tests__/password-generator-client.test.tsx
+++ b/__tests__/password-generator-client.test.tsx
@@ -14,4 +14,16 @@ describe('PasswordGeneratorClient', () => {
     await user.click(button);
     expect(input.value).not.toBe(before);
   });
+
+  test('pattern field disables length slider', async () => {
+    const user = userEvent.setup();
+    render(<PasswordGeneratorClient />);
+    const slider = screen.getByRole('slider');
+    expect(slider).not.toBeDisabled();
+    const patternInput = screen.getByLabelText(/pattern/i);
+    await user.type(patternInput, 'Aa0');
+    expect(slider).toBeDisabled();
+    await user.clear(patternInput);
+    expect(slider).not.toBeDisabled();
+  });
 });

--- a/app/tools/password-generator/password-generator-client.tsx
+++ b/app/tools/password-generator/password-generator-client.tsx
@@ -22,20 +22,22 @@ export default function PasswordGeneratorClient() {
   const [password, setPassword] = useState("");
   const [copied, setCopied] = useState(false);
 
+  const isPatternMode = pattern.trim().length > 0;
+
   const generate = useCallback(() => {
     const pwd = generatePassword({
       length,
-      upper: useUpper,
-      lower: useLower,
-      digits: useDigits,
-      symbols: useSymbols,
+      upper: isPatternMode ? undefined : useUpper,
+      lower: isPatternMode ? undefined : useLower,
+      digits: isPatternMode ? undefined : useDigits,
+      symbols: isPatternMode ? undefined : useSymbols,
       excludeSimilar,
       pattern: pattern || undefined,
       avoidRepeats,
-      minUpper: useUpper ? minUpper : undefined,
-      minLower: useLower ? minLower : undefined,
-      minDigits: useDigits ? minDigits : undefined,
-      minSymbols: useSymbols ? minSymbols : undefined,
+      minUpper: isPatternMode || !useUpper ? undefined : minUpper,
+      minLower: isPatternMode || !useLower ? undefined : minLower,
+      minDigits: isPatternMode || !useDigits ? undefined : minDigits,
+      minSymbols: isPatternMode || !useSymbols ? undefined : minSymbols,
     });
     setPassword(pwd);
     setCopied(false);
@@ -77,18 +79,18 @@ export default function PasswordGeneratorClient() {
 
   const cliCommand = [
     "gearizen-password-generator",
-    `--length ${length}`,
-    useUpper ? "--upper" : "",
-    useLower ? "--lower" : "",
-    useDigits ? "--digits" : "",
-    useSymbols ? "--symbols" : "",
+    !isPatternMode ? `--length ${length}` : "",
+    !isPatternMode && useUpper ? "--upper" : "",
+    !isPatternMode && useLower ? "--lower" : "",
+    !isPatternMode && useDigits ? "--digits" : "",
+    !isPatternMode && useSymbols ? "--symbols" : "",
     excludeSimilar ? "--exclude-similar" : "",
     pattern ? `--pattern ${pattern}` : "",
     avoidRepeats ? "--avoid-repeats" : "",
-    useUpper ? `--min-upper ${minUpper}` : "",
-    useLower ? `--min-lower ${minLower}` : "",
-    useDigits ? `--min-digits ${minDigits}` : "",
-    useSymbols ? `--min-symbols ${minSymbols}` : "",
+    !isPatternMode && useUpper ? `--min-upper ${minUpper}` : "",
+    !isPatternMode && useLower ? `--min-lower ${minLower}` : "",
+    !isPatternMode && useDigits ? `--min-digits ${minDigits}` : "",
+    !isPatternMode && useSymbols ? `--min-symbols ${minSymbols}` : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -174,6 +176,9 @@ export default function PasswordGeneratorClient() {
             Use A for uppercase, a for lowercase, 0 for numbers, $ for symbols,
             ? for any.
           </p>
+          {isPatternMode && (
+            <p className="text-sm text-gray-500">Pattern overrides length and character settings.</p>
+          )}
         </div>
         {/* Length Slider */}
         <div>
@@ -194,9 +199,9 @@ export default function PasswordGeneratorClient() {
             aria-valuemax={64}
             aria-valuenow={length}
             className="w-full"
-            disabled={pattern !== ""}
+            disabled={isPatternMode}
           />
-          {pattern && (
+          {isPatternMode && (
             <p className="text-sm text-gray-500 mt-1">
               Length is determined by pattern.
             </p>
@@ -208,44 +213,51 @@ export default function PasswordGeneratorClient() {
           <legend className="text-lg font-semibold text-gray-800 mb-2">
             Include Characters
           </legend>
-          <div className="grid grid-cols-2 gap-4">
-            <label className="flex items-center space-x-2 col-span-2">
+          {isPatternMode && (
+            <p className="text-sm text-gray-500">Character options disabled in pattern mode.</p>
+          )}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex items-center space-x-2">
               <input
                 type="checkbox"
                 checked={useUpper}
                 onChange={() => setUseUpper((u) => !u)}
+                disabled={isPatternMode}
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
               <span className="text-gray-700 select-none">Uppercase (A–Z)</span>
             </label>
-            <label className="flex items-center space-x-2 col-span-2">
+            <label className="flex items-center space-x-2">
               <input
                 type="checkbox"
                 checked={useLower}
                 onChange={() => setUseLower((u) => !u)}
+                disabled={isPatternMode}
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
               <span className="text-gray-700 select-none">Lowercase (a–z)</span>
             </label>
-            <label className="flex items-center space-x-2 col-span-2">
+            <label className="flex items-center space-x-2">
               <input
                 type="checkbox"
                 checked={useDigits}
                 onChange={() => setUseDigits((d) => !d)}
+                disabled={isPatternMode}
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
               <span className="text-gray-700 select-none">Numbers (0–9)</span>
             </label>
-            <label className="flex items-center space-x-2 col-span-2">
+            <label className="flex items-center space-x-2">
               <input
                 type="checkbox"
                 checked={useSymbols}
                 onChange={() => setUseSymbols((s) => !s)}
+                disabled={isPatternMode}
                 className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
               />
               <span className="text-gray-700 select-none">Symbols (!@#$%)</span>
             </label>
-            <label className="flex items-center space-x-2 col-span-2">
+            <label className="flex items-center space-x-2">
               <input
                 type="checkbox"
                 checked={excludeSimilar}
@@ -285,48 +297,51 @@ export default function PasswordGeneratorClient() {
           <legend className="text-lg font-semibold text-gray-800 mb-2">
             Minimum Counts
           </legend>
-          <div className="grid grid-cols-2 gap-4">
-            <label className="flex items-center space-x-2 col-span-2">
+          {isPatternMode && (
+            <p className="text-sm text-gray-500">Minimum counts disabled in pattern mode.</p>
+          )}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex items-center space-x-2">
               <span className="text-gray-700 select-none">Uppercase</span>
               <input
                 type="number"
                 min={0}
                 value={minUpper}
                 onChange={(e) => setMinUpper(Number(e.target.value))}
-                disabled={!useUpper}
+                disabled={!useUpper || isPatternMode}
                 className="w-20 input-base"
               />
             </label>
-            <label className="flex items-center space-x-2 col-span-2">
+            <label className="flex items-center space-x-2">
               <span className="text-gray-700 select-none">Lowercase</span>
               <input
                 type="number"
                 min={0}
                 value={minLower}
                 onChange={(e) => setMinLower(Number(e.target.value))}
-                disabled={!useLower}
+                disabled={!useLower || isPatternMode}
                 className="w-20 input-base"
               />
             </label>
-            <label className="flex items-center space-x-2 col-span-2">
+            <label className="flex items-center space-x-2">
               <span className="text-gray-700 select-none">Digits</span>
               <input
                 type="number"
                 min={0}
                 value={minDigits}
                 onChange={(e) => setMinDigits(Number(e.target.value))}
-                disabled={!useDigits}
+                disabled={!useDigits || isPatternMode}
                 className="w-20 input-base"
               />
             </label>
-            <label className="flex items-center space-x-2 col-span-2">
+            <label className="flex items-center space-x-2">
               <span className="text-gray-700 select-none">Symbols</span>
               <input
                 type="number"
                 min={0}
                 value={minSymbols}
                 onChange={(e) => setMinSymbols(Number(e.target.value))}
-                disabled={!useSymbols}
+                disabled={!useSymbols || isPatternMode}
                 className="w-20 input-base"
               />
             </label>

--- a/lib/generate-password.ts
+++ b/lib/generate-password.ts
@@ -47,39 +47,43 @@ function randomChar(set: string): string {
 export function generatePassword(options: PasswordOptions): string {
   const excludeSimilar = !!options.excludeSimilar;
 
-  // Pattern mode
+  // Pattern mode ignores other configuration besides excludeSimilar and
+  // avoidRepeats. '?' and '*' pull from the full character pool.
   if (options.pattern) {
     const pattern = options.pattern;
+    const anySet = filterSet(
+      UPPER + LOWER + DIGITS + SYMBOLS,
+      excludeSimilar,
+    );
     const out: string[] = [];
     for (const char of pattern) {
+      let next = char;
       switch (char) {
         case "A":
-          out.push(randomChar(filterSet(UPPER, excludeSimilar)));
+          next = randomChar(filterSet(UPPER, excludeSimilar));
           break;
         case "a":
-          out.push(randomChar(filterSet(LOWER, excludeSimilar)));
+          next = randomChar(filterSet(LOWER, excludeSimilar));
           break;
         case "0":
-          out.push(randomChar(filterSet(DIGITS, excludeSimilar)));
+          next = randomChar(filterSet(DIGITS, excludeSimilar));
           break;
         case "$":
-          out.push(randomChar(filterSet(SYMBOLS, excludeSimilar)));
+          next = randomChar(filterSet(SYMBOLS, excludeSimilar));
           break;
         case "?":
         case "*":
-          out.push(
-            randomChar(
-              (options.upper ? filterSet(UPPER, excludeSimilar) : "") +
-                (options.lower ? filterSet(LOWER, excludeSimilar) : "") +
-                (options.digits ? filterSet(DIGITS, excludeSimilar) : "") +
-                (options.symbols ? filterSet(SYMBOLS, excludeSimilar) : "") ||
-                UPPER + LOWER + DIGITS,
-            ),
-          );
+          next = randomChar(anySet);
           break;
         default:
-          out.push(char);
+          next = char;
       }
+      if (options.avoidRepeats && out[out.length - 1] === next) {
+        let alt = randomChar(anySet);
+        while (alt === next) alt = randomChar(anySet);
+        next = alt;
+      }
+      out.push(next);
     }
     return out.join("");
   }


### PR DESCRIPTION
## Summary
- enhance `generatePassword` to ignore options when a pattern is used
- update password generator page for pattern mode
- refine CLI command generation
- cover new behaviour with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68727c9c99f48325bfc1b800d19e2dcb