### PR TITLE
Enhance contact page with dynamic form

### DIFF
--- a/__tests__/contact-form.test.ts
+++ b/__tests__/contact-form.test.ts
@@ -1,0 +1,21 @@
+import { validate, buildMailto, obfuscateEmail } from '../lib/contactForm';
+
+describe('contact form utils', () => {
+  test('validate detects required fields', () => {
+    const fields = [
+      { name: 'name', label: 'Name', required: true },
+      { name: 'email', label: 'Email', required: true },
+    ];
+    const errors = validate({ name: 'John', email: '' }, fields);
+    expect(errors).toEqual({ email: 'Email is required' });
+  });
+
+  test('buildMailto encodes params', () => {
+    const mail = buildMailto('a@example.com', { name: 'J', message: 'Hi' });
+    expect(mail).toBe('mailto:a@example.com?name=J&message=Hi');
+  });
+
+  test('obfuscateEmail converts characters to entities', () => {
+    expect(obfuscateEmail('a@b.com')).toContain('&#97;');
+  });
+});

--- a/app/contact/contact-client.tsx
+++ b/app/contact/contact-client.tsx
@@ -1,8 +1,50 @@
 "use client";
-import { useSearchParams } from "next/navigation";
+
+import { FormEvent, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import contactConfig from "@/lib/contactConfig";
+import { buildMailto, validate, obfuscateEmail } from "@/lib/contactForm";
+import Input from "@/components/Input";
+import Textarea from "@/components/Textarea";
+import Button from "@/components/Button";
+
+function getIcon(name: string) {
+  return dynamic(() => import("react-icons/fa").then((m) => (m as any)[name]), {
+    ssr: false,
+  });
+}
 
 export default function ContactClient() {
-  const success = useSearchParams().get("success") === "1";
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const data = new FormData(form);
+    const values: Record<string, string> = {};
+    contactConfig.formFields.forEach((f) => {
+      values[f.name] = (data.get(f.name) as string) || "";
+    });
+    const errs = validate(values, contactConfig.formFields);
+    if (Object.keys(errs).length) {
+      setErrors(errs);
+      setStatus("error");
+      return;
+    }
+    setErrors({});
+    const mailto = buildMailto(contactConfig.emails[0], values);
+    window.location.href = mailto;
+    setStatus("success");
+    form.reset();
+  };
+
+  const emailLink = useMemo(
+    () => obfuscateEmail(contactConfig.emails[0]),
+    []
+  );
+
   return (
     <section
       id="contact-gearizen"
@@ -16,20 +58,107 @@ export default function ContactClient() {
         Contact Us
       </h1>
       <p className="text-lg text-gray-700 mb-12 max-w-xl mx-auto text-center">
-        Have questions or feedback? Please email us at
-        <a href="mailto:gearizen.tahir.ozcan@gmail.com" className="text-indigo-600 underline ml-1">
-          gearizen.tahir.ozcan@gmail.com
-        </a>
+        Have questions or feedback? Reach us via the form below or email us at{' '}
+        <a
+          href={`mailto:${contactConfig.emails[0]}`}
+          dangerouslySetInnerHTML={{ __html: emailLink }}
+          className="text-indigo-600 underline"
+        />
         .
       </p>
-      {success && (
-        <div
-          role="status"
-          className="max-w-md mx-auto bg-green-50 border border-green-200 text-green-800 p-6 rounded-lg text-center"
+
+      <div className="grid gap-12 lg:grid-cols-2">
+        <form
+          ref={formRef}
+          onSubmit={handleSubmit}
+          action={`mailto:${contactConfig.emails[0]}`}
+          method="post"
+          className="space-y-6"
         >
-          <p className="font-medium text-lg">Thank you! Your message has been sent.</p>
-        </div>
-      )}
+          {contactConfig.formFields.map((field) => (
+            <div
+              key={field.name}
+              className="flex flex-col sm:flex-row sm:items-center sm:gap-4 lg:flex-col lg:items-start"
+            >
+              <label
+                htmlFor={field.name}
+                className="mb-2 sm:mb-0 sm:w-32 font-medium text-gray-800"
+              >
+                {field.label}
+                {field.required && <span className="text-red-600">*</span>}
+              </label>
+              {field.type === "textarea" ? (
+                <Textarea
+                  id={field.name}
+                  name={field.name}
+                  required={field.required}
+                  rows={5}
+                  className="sm:flex-1"
+                />
+              ) : (
+                <Input
+                  id={field.name}
+                  name={field.name}
+                  type={field.type}
+                  required={field.required}
+                  className="sm:flex-1"
+                />
+              )}
+              {errors[field.name] && (
+                <span
+                  role="alert"
+                  className="text-sm text-red-600 mt-1 sm:ml-4"
+                  aria-live="assertive"
+                >
+                  {errors[field.name]}
+                </span>
+              )}
+            </div>
+          ))}
+          <Button type="submit" className="w-full sm:w-auto">
+            Send Message
+          </Button>
+          {status === "success" && (
+            <div
+              role="status"
+              className="bg-green-50 border border-green-200 text-green-800 p-4 rounded-md mt-4"
+            >
+              Thank you! Your message has been prepared in your email client.
+            </div>
+          )}
+          {status === "error" && Object.keys(errors).length > 0 && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="bg-red-50 border border-red-200 text-red-800 p-4 rounded-md mt-4"
+            >
+              Please correct the highlighted fields.
+            </div>
+          )}
+        </form>
+
+        <address className="not-italic space-y-4 text-gray-700">
+          <h2 className="text-xl font-semibold">Other Channels</h2>
+          <ul className="space-y-2">
+            {contactConfig.social.map((s) => {
+              const Icon = getIcon(s.icon);
+              return (
+                <li key={s.href} className="flex items-center space-x-2">
+                  <Icon className="w-5 h-5" aria-hidden="true" />
+                  <a
+                    href={s.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+                  >
+                    {s.label}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </address>
+      </div>
     </section>
   );
 }

--- a/docs/contact-guide.md
+++ b/docs/contact-guide.md
@@ -1,0 +1,30 @@
+# Contact Page Config & UX Guide
+
+This document outlines how the Gearizen contact page is configured and how the form behaves.
+
+## Configuration
+
+The contact page reads its options from `lib/contact-config.json`. This file defines:
+
+- **emails** – array of email addresses used for `mailto:` links
+- **social** – list of social or chat channels with an icon name and URL
+- **formFields** – ordered fields rendered in the contact form
+
+Adding or removing entries updates the page automatically without code changes. Icons use names from `react-icons/fa`.
+
+## Form Behaviour
+
+The form progressively enhances:
+
+1. **HTML fallback** – without JavaScript the form posts to the first email address via `mailto:`.
+2. **JavaScript enabled** – submission is intercepted to validate required fields and then open the user’s mail client using a composed `mailto:` link. Success and error feedback is shown inside the page using ARIA live regions.
+
+Validation logic lives in `lib/contactForm.ts` and is covered by unit tests.
+
+## Responsive Layout
+
+- Fields stack vertically on small screens.
+- Labels and inputs align inline from the `sm` breakpoint.
+- On `lg` screens the page uses a two‑column layout with the form alongside the contact methods list.
+
+All interactive elements meet keyboard and touch target guidelines and follow the site’s global styling utilities.

--- a/e2e/contact.spec.ts
+++ b/e2e/contact.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// Basic E2E coverage for the contact page
+
+test.describe('contact page', () => {
+  test('form submits and shows success message', async ({ page }) => {
+    await page.goto('/contact');
+    await page.fill('input[name="name"]', 'John Doe');
+    await page.fill('input[name="email"]', 'john@example.com');
+    await page.fill('textarea[name="message"]', 'Hi');
+    await page.click('button[type="submit"]');
+    await expect(page.getByRole('status')).toBeVisible();
+  });
+
+  test('discord link is driven by config', async ({ page }) => {
+    await page.goto('/contact');
+    const link = page.getByRole('link', { name: 'Discord' });
+    await expect(link).toHaveAttribute('href', /discord/);
+  });
+});

--- a/lib/contact-config.json
+++ b/lib/contact-config.json
@@ -1,0 +1,15 @@
+{
+  "emails": ["gearizen.tahir.ozcan@gmail.com"],
+  "social": [
+    { "label": "GitHub", "href": "https://github.com/tahir-ozcan/gearizen", "icon": "FaGithub" },
+    { "label": "Twitter", "href": "https://twitter.com/gearizen", "icon": "FaTwitter" },
+    { "label": "LinkedIn", "href": "https://linkedin.com/company/gearizen", "icon": "FaLinkedin" },
+    { "label": "Discord", "href": "https://discord.gg/gearizen", "icon": "FaDiscord" }
+  ],
+  "formFields": [
+    { "name": "name", "label": "Name", "type": "text", "required": true },
+    { "name": "email", "label": "Email", "type": "email", "required": true },
+    { "name": "subject", "label": "Subject", "type": "text" },
+    { "name": "message", "label": "Message", "type": "textarea", "required": true }
+  ]
+}

--- a/lib/contactConfig.ts
+++ b/lib/contactConfig.ts
@@ -1,0 +1,23 @@
+import data from './contact-config.json';
+
+export interface ContactFormField {
+  name: string;
+  label: string;
+  type: 'text' | 'email' | 'textarea';
+  required?: boolean;
+}
+
+export interface ContactChannel {
+  label: string;
+  href: string;
+  icon: string;
+}
+
+export interface ContactConfig {
+  emails: string[];
+  social: ContactChannel[];
+  formFields: ContactFormField[];
+}
+
+const contactConfig = data as ContactConfig;
+export default contactConfig;

--- a/lib/contactForm.ts
+++ b/lib/contactForm.ts
@@ -1,0 +1,29 @@
+export interface FormValues {
+  [key: string]: string;
+}
+
+export function validate(values: FormValues, fields: { name: string; label: string; required?: boolean }[]): Record<string, string> {
+  const errors: Record<string, string> = {};
+  for (const f of fields) {
+    const value = values[f.name]?.trim();
+    if (f.required && !value) {
+      errors[f.name] = `${f.label} is required`;
+    }
+  }
+  return errors;
+}
+
+export function buildMailto(email: string, values: FormValues): string {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(values)) {
+    if (v) params.set(k, v);
+  }
+  return `mailto:${email}?${params.toString()}`;
+}
+
+export function obfuscateEmail(email: string): string {
+  return email
+    .split('')
+    .map((ch) => `&#${ch.charCodeAt(0)};`)
+    .join('');
+}


### PR DESCRIPTION
## Summary
- add dynamic contact config and utilities
- implement responsive contact form with validation
- document contact page config and UX guidelines
- add unit test for form validation
- create basic E2E spec for contact page

## Testing
- `npm test --silent`
- `npm run test:e2e --silent` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68728ba49f788325b210867a28fc5f15