### PR TITLE
Refactor home page with configurable layout

### DIFF
--- a/HOME_PAGE_STYLE_GUIDE.md
+++ b/HOME_PAGE_STYLE_GUIDE.md
@@ -1,0 +1,25 @@
+# Home Page Style & Config Guide
+
+This document outlines how the Gearizen Home page pulls its content and the recommended styling conventions.
+
+## Configuration
+
+- **data/home.json** – Contains the hero section text and the list of feature cards. It can be edited or replaced by a CMS in the future.
+- **lib/home-data.ts** – Provides TypeScript types and a helper `getHomeData()` used by the client component.
+
+Modifying the JSON allows you to change the hero headline, sub‑headline, CTA label/link and the order or content of the feature cards without touching the React code.
+
+## Styling
+
+- Uses the global Tailwind utility classes defined in `app/globals.css`.
+- Layout is mobile‑first: single column by default, two columns on small screens, grid on larger breakpoints.
+- Feature icons are rendered via the dynamic `ToolCard` component which loads Lucide icons on demand.
+- Maintain accessible focus styles for links and buttons using the `.focus-visible` utilities.
+- To add a new tool card, append an entry in the JSON and it will automatically render.
+
+## Components
+
+- **app/home-client.tsx** – Renders the hero section and feature grid using data from `getHomeData()`.
+- **components/ToolCard.tsx** – Shared card component handling icon loading and link semantics.
+
+Keep all imagery optimized (SVG where possible) and ensure any new interactive elements meet keyboard and screen‑reader accessibility standards.

--- a/__tests__/home-data.test.ts
+++ b/__tests__/home-data.test.ts
@@ -1,0 +1,14 @@
+import { getHomeData } from '../lib/home-data';
+
+describe('getHomeData utility', () => {
+  test('returns hero configuration and features', () => {
+    const data = getHomeData();
+    expect(data.hero.title).toBe('Gearizen');
+    expect(Array.isArray(data.features)).toBe(true);
+    expect(data.features.length).toBeGreaterThan(0);
+    for (const feat of data.features) {
+      expect(feat).toHaveProperty('href');
+      expect(feat).toHaveProperty('icon');
+    }
+  });
+});

--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { Suspense } from "react";
+import dynamic from "next/dynamic";
+import { HelpCircle } from "lucide-react";
+import CardLink from "../components/CardLink";
+import { getHomeData } from "../lib/home-data";
+
+const ToolCard = dynamic(() => import("../components/ToolCard"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-48 rounded-2xl bg-gray-100 animate-pulse" aria-hidden="true" />
+  ),
+});
+
+export default function HomeClient() {
+  const { hero, features } = getHomeData();
+  return (
+    <div className="text-gray-900 selection:bg-indigo-200 selection:text-indigo-900">
+      {/* Hero Section */}
+      <section
+        aria-labelledby="hero-heading"
+        className="pt-20 pb-16 text-center"
+      >
+        <h1
+          id="hero-heading"
+          className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight"
+        >
+          {hero.title}
+        </h1>
+        <p className="mt-4 text-lg sm:text-xl md:text-2xl text-gray-700 max-w-2xl mx-auto leading-relaxed">
+          {hero.subHeadline}
+        </p>
+        <Link
+          href={hero.ctaHref}
+          aria-label={hero.ctaLabel}
+          className="mt-8 inline-block bg-indigo-600 text-white font-semibold rounded-full px-8 py-3 shadow-md hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition-colors"
+        >
+          {hero.ctaLabel}
+        </Link>
+      </section>
+
+      {/* Popular Tools */}
+      <section aria-labelledby="tools-heading" className="pb-20">
+        <h2
+          id="tools-heading"
+          className="text-3xl sm:text-4xl font-semibold text-gray-800 text-center"
+        >
+          Popular & Essential Tools
+        </h2>
+        <ul className="mt-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+          {features.map((tool) => (
+            <li key={tool.href} className="list-none">
+              <Suspense fallback={<div className="h-48 rounded-2xl bg-gray-100 animate-pulse" aria-hidden="true" />}> 
+                <ToolCard {...tool} />
+              </Suspense>
+            </li>
+          ))}
+          <li className="list-none">
+            <CardLink
+              href="/contact"
+              aria-label="Suggest a tool to the Gearizen team"
+              className="group flex flex-col items-center justify-center border-dashed border-gray-300 text-center"
+            >
+              <HelpCircle
+                aria-hidden="true"
+                className="w-10 h-10 text-gray-400 mb-4"
+              />
+              <h3 className="text-xl font-semibold mb-2 text-gray-700">
+                Suggest a Tool
+              </h3>
+              <p className="text-gray-500 max-w-xs">
+                Have an idea? Let us know what tool you’d like to see next.
+              </p>
+            </CardLink>
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,7 @@
 // app/page.tsx
 
-import Link from "next/link";
-import CardLink from "@/components/CardLink";
-import {
-  Key,
-  FilePlus,
-  QrCode,
-  ArrowRightLeft,
-  ImageIcon,
-  HelpCircle,
-} from "lucide-react";
 import JsonLd from "./components/JsonLd";
+import HomeClient from "./home-client";
 
 export const metadata = {
   metadataBase: new URL("https://gearizen.com"),
@@ -57,127 +48,11 @@ const websiteJsonLd = {
   },
 };
 
-const popularTools = [
-  {
-    href: "/tools/password-generator",
-    icon: <Key aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
-    title: "Password Generator",
-    description: "Generate strong, customizable passwords instantly.",
-  },
-  {
-    href: "/tools/pdf-to-word",
-    icon: <FilePlus aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
-    title: "PDF → Word Converter",
-    description: "Convert PDFs to editable Word documents quickly.",
-  },
-  {
-    href: "/tools/qr-code-generator",
-    icon: <QrCode aria-hidden="true" className="w-10 h-10 text-indigo-600" />,
-    title: "QR Code Generator",
-    description: "Create QR codes for URLs, text, contacts, and more.",
-  },
-  {
-    href: "/tools/unit-converter",
-    icon: (
-      <ArrowRightLeft
-        aria-hidden="true"
-        className="w-10 h-10 text-indigo-600"
-      />
-    ),
-    title: "Unit Converter",
-    description: "Convert between metric and imperial units easily.",
-  },
-  {
-    href: "/tools/image-compressor",
-    icon: (
-      <ImageIcon aria-hidden="true" className="w-10 h-10 text-indigo-600" />
-    ),
-    title: "Image Compressor",
-    description: "Reduce image file sizes while preserving quality.",
-  },
-];
-
 export default function HomePage() {
   return (
-    <div className="bg-white text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900">
+    <>
       <JsonLd data={websiteJsonLd} />
-      {/* Hero */}
-      <section
-        aria-labelledby="hero-heading"
-        className="container-responsive pt-20 pb-16 text-center"
-      >
-        <h1
-          id="hero-heading"
-          className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight"
-        >
-          Gearizen
-        </h1>
-        <p className="mt-4 text-lg sm:text-xl md:text-2xl text-gray-700 max-w-2xl mx-auto leading-relaxed">
-          Free, fast, privacy-first web tools for developers, creators, and
-          everyone. No signup, no tracking, 100% client-side.
-        </p>
-        <Link
-          href="/tools"
-          className="mt-8 inline-block bg-indigo-600 text-white font-semibold rounded-full px-8 py-3 shadow-md hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 transition-colors"
-        >
-          Discover All Tools
-        </Link>
-      </section>
-
-      {/* Popular Tools */}
-      <section
-        aria-labelledby="tools-heading"
-        className="container-responsive pb-20"
-      >
-        <h2
-          id="tools-heading"
-          className="text-3xl sm:text-4xl font-semibold text-gray-800 text-center"
-        >
-          Popular & Essential Tools
-        </h2>
-
-        <ul className="mt-8 grid gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-          {popularTools.map(({ href, icon, title, description }) => (
-            <li key={href} className="list-none">
-              <CardLink
-                href={href}
-                aria-label={`Navigate to ${title}`}
-                className="group flex flex-col h-full"
-              >
-                <div className="mb-6 flex items-center justify-center">
-                  {icon}
-                </div>
-                <h3 className="text-xl font-semibold mb-2 text-center group-hover:text-indigo-600 transition-colors">
-                  {title}
-                </h3>
-                <p className="text-gray-600 flex-grow text-center">
-                  {description}
-                </p>
-              </CardLink>
-            </li>
-          ))}
-
-          {/* Suggest a Tool */}
-          <li className="list-none">
-            <CardLink
-              href="/contact"
-              aria-label="Suggest a tool to the Gearizen team"
-              className="group flex flex-col items-center justify-center border-dashed border-gray-300 text-center"
-            >
-              <HelpCircle
-                aria-hidden="true"
-                className="w-10 h-10 text-gray-400 mb-4"
-              />
-              <h3 className="text-xl font-semibold mb-2 text-gray-700">
-                Suggest a Tool
-              </h3>
-              <p className="text-gray-500 max-w-xs">
-                Have an idea? Let us know what tool you’d like to see next.
-              </p>
-            </CardLink>
-          </li>
-        </ul>
-      </section>
-    </div>
+      <HomeClient />
+    </>
   );
 }

--- a/data/home.json
+++ b/data/home.json
@@ -1,0 +1,40 @@
+{
+  "hero": {
+    "title": "Gearizen",
+    "subHeadline": "Free, fast, privacy-first web tools for developers, creators, and everyone. No signup, no tracking, 100% client-side.",
+    "ctaLabel": "Discover All Tools",
+    "ctaHref": "/tools"
+  },
+  "features": [
+    {
+      "href": "/tools/password-generator",
+      "icon": "Key",
+      "title": "Password Generator",
+      "description": "Generate strong, customizable passwords instantly."
+    },
+    {
+      "href": "/tools/pdf-to-word",
+      "icon": "FilePlus",
+      "title": "PDF → Word Converter",
+      "description": "Convert PDFs to editable Word documents quickly."
+    },
+    {
+      "href": "/tools/qr-code-generator",
+      "icon": "QrCode",
+      "title": "QR Code Generator",
+      "description": "Create QR codes for URLs, text, contacts, and more."
+    },
+    {
+      "href": "/tools/unit-converter",
+      "icon": "ArrowRightLeft",
+      "title": "Unit Converter",
+      "description": "Convert between metric and imperial units easily."
+    },
+    {
+      "href": "/tools/image-compressor",
+      "icon": "ImageIcon",
+      "title": "Image Compressor",
+      "description": "Reduce image file sizes while preserving quality."
+    }
+  ]
+}

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,8 +1,18 @@
 import { test, expect } from '@playwright/test';
 
-// Simple check that the homepage renders and has expected heading
+test.describe('home page', () => {
+  test('hero CTA navigates to tools', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Gearizen' })).toBeVisible();
+    await page.getByRole('link', { name: 'Discover All Tools' }).click();
+    await expect(page).toHaveURL(/\/tools$/);
+  });
 
-test('homepage loads', async ({ page }) => {
-  await page.goto('http://localhost:3000');
-  await expect(page.getByRole('heading', { name: 'Gearizen' })).toBeVisible();
+  test('mobile navigation works', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    await page.getByRole('link', { name: 'About' }).click();
+    await expect(page).toHaveURL(/\/about$/);
+  });
 });

--- a/lib/home-data.ts
+++ b/lib/home-data.ts
@@ -1,0 +1,24 @@
+import homeData from '../data/home.json';
+
+export interface HeroConfig {
+  title: string;
+  subHeadline: string;
+  ctaLabel: string;
+  ctaHref: string;
+}
+
+export interface FeatureCard {
+  href: string;
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface HomeData {
+  hero: HeroConfig;
+  features: FeatureCard[];
+}
+
+export function getHomeData(): HomeData {
+  return homeData as HomeData;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-config-next": "15.3.5",
         "husky": "^8.0.0",
         "jest": "^30.0.4",
+        "jest-environment-jsdom": "^30.0.4",
         "lint-staged": "^16.1.2",
         "next-sitemap": "^4.2.3",
         "prettier": "^3.0.0",
@@ -1813,6 +1814,34 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.0.4.tgz",
+      "integrity": "sha512-pUKfqgr5Nki9kZ/3iV+ubDsvtPq0a0oNL6zqkKLM1tPQI8FBJeuWskvW1kzc5pOvqlgpzumYZveJ4bxhANY0hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.0.4",
+        "@jest/fake-timers": "30.0.4",
+        "@jest/types": "30.0.1",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.0.2",
+        "jest-util": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jest/expect": {
       "version": "30.0.4",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.0.4.tgz",
@@ -3215,6 +3244,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3326,6 +3367,13 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -8012,6 +8060,31 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.0.4.tgz",
+      "integrity": "sha512-9WmS3oyCLFgs6DUJSoMpVb+AbH62Y2Xecw3XClbRgj6/Z+VjNeSLjrhBgVvTZ40njZTWeDHv8unp+6M/z8ADDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.0.4",
+        "@jest/environment-jsdom-abstract": "30.0.4",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-next": "15.3.5",
     "husky": "^8.0.0",
     "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
     "lint-staged": "^16.1.2",
     "next-sitemap": "^4.2.3",
     "prettier": "^3.0.0",


### PR DESCRIPTION
## Summary
- split Home page into server + client files
- pull hero and feature card info from new JSON config
- add TypeScript helpers for home data
- update Playwright tests for CTA navigation
- provide Home Page Style & Config Guide
- ensure unit tests for config utility

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68728b2ee900832587eea2e6b82d281e