### PR TITLE
Refactor privacy policy page

### DIFF
--- a/__tests__/privacy-policy-client.test.tsx
+++ b/__tests__/privacy-policy-client.test.tsx
@@ -1,0 +1,9 @@
+/** @jest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import PrivacyClient from '../app/privacy/privacy-client';
+
+it('renders policy sections from JSON', () => {
+  render(<PrivacyClient />);
+  const heading = screen.getByRole('heading', { name: 'Data We Don\u2019t Collect' });
+  expect(heading).toBeInTheDocument();
+});

--- a/__tests__/privacy-policy.test.ts
+++ b/__tests__/privacy-policy.test.ts
@@ -1,0 +1,21 @@
+import { getPrivacyPolicySections } from '../lib/privacyPolicy';
+import { renderMarkdown } from '../lib/render-markdown';
+
+describe('privacy policy utilities', () => {
+  test('parses json into sections', () => {
+    const sections = getPrivacyPolicySections();
+    expect(Array.isArray(sections)).toBe(true);
+    expect(sections.length).toBeGreaterThan(0);
+    sections.forEach((s) => {
+      expect(typeof s.id).toBe('string');
+      expect(typeof s.title).toBe('string');
+      expect(typeof s.content).toBe('string');
+    });
+  });
+
+  test('renders markdown to html', () => {
+    const [first] = getPrivacyPolicySections();
+    const html = renderMarkdown(first.content);
+    expect(html).toContain('<');
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -53,4 +53,12 @@
   .json-null {
     @apply text-gray-500;
   }
+
+  .policy-list {
+    @apply list-disc list-inside space-y-2;
+  }
+
+  .policy-text a {
+    @apply text-indigo-600 underline hover:text-indigo-800;
+  }
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -17,7 +17,7 @@ export const metadata = {
     "privacy-focused tools",
   ],
   authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
-  robots: { index: true, follow: true },
+  robots: { index: true, follow: true, noarchive: true },
   alternates: { canonical: "https://gearizen.com/privacy" },
   openGraph: {
     title: "Privacy Policy | Gearizen",

--- a/app/privacy/privacy-client.tsx
+++ b/app/privacy/privacy-client.tsx
@@ -2,15 +2,44 @@
 
 "use client";
 
-import Link from "next/link";
+import { useEffect, useState } from "react";
+import { renderMarkdown } from "@/lib/render-markdown";
+import { getPrivacyPolicySections } from "@/lib/privacyPolicy";
 
 export default function PrivacyClient() {
+  const sections = getPrivacyPolicySections();
+  const [active, setActive] = useState<string>(sections[0]?.id);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "-40% 0px -55% 0px" }
+    );
+    sections.forEach((s) => {
+      const el = document.getElementById(s.id);
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, [sections]);
+
   return (
     <section
       id="privacy-policy"
       aria-labelledby="privacy-heading"
       className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
+      <a
+        href={`#${sections[0]?.id}`}
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md z-40"
+      >
+        Skip to policy
+      </a>
       <h1
         id="privacy-heading"
         className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold mb-8 tracking-tight text-center"
@@ -31,80 +60,45 @@ export default function PrivacyClient() {
         text converters, QR code tools, and more—completely anonymously.
       </p>
 
-      <div className="space-y-12 max-w-3xl mx-auto">
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Data We Don’t Collect
-          </h2>
-          <ul className="list-disc list-inside space-y-2 text-lg leading-relaxed">
-            <li>No personal information (name, address, email, etc.)</li>
-            <li>No file uploads or storage on our servers</li>
-            <li>No IP address logging</li>
-            <li>No behavioral analytics or usage tracking</li>
+      <div className="md:grid md:grid-cols-[200px_1fr] md:gap-12">
+        {/* Table of contents */}
+        <nav
+          aria-label="On this page"
+          className="hidden md:block sticky top-24 self-start"
+        >
+          <ul className="space-y-2 border-l border-gray-200 pl-4 text-sm">
+            {sections.map((s) => (
+              <li key={s.id}>
+                <a
+                  href={`#${s.id}`}
+                  className={`transition-colors hover:text-gray-900 ${
+                    active === s.id
+                      ? "text-indigo-600 font-semibold"
+                      : "text-gray-700"
+                  }`}
+                >
+                  {s.title}
+                </a>
+              </li>
+            ))}
           </ul>
-        </section>
+        </nav>
 
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Advertising & Third-Party Services
-          </h2>
-          <p className="text-lg leading-relaxed">
-            We display ads via third-party networks (e.g., Google Ads). Those
-            providers may set their own cookies or trackers; please review their
-            privacy policies. Gearizen does not share any personally
-            identifiable data with advertisers.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Cookies
-          </h2>
-          <p className="text-lg leading-relaxed">
-            Gearizen itself does not use cookies. However, third-party ad
-            networks may drop cookies under their own policies. You can manage
-            those through your browser settings.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Your Rights
-          </h2>
-          <p className="text-lg leading-relaxed">
-            Since we collect no personal data, there is nothing for you to
-            access, modify, or delete. Your interactions remain private on your
-            device.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Policy Updates
-          </h2>
-          <p className="text-lg leading-relaxed">
-            We may update this policy to reflect changes in our tools or
-            applicable laws. Please revisit this page periodically to stay
-            informed.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Contact Us
-          </h2>
-          <p className="text-lg leading-relaxed">
-            If you have questions about this policy, please{" "}
-            <Link
-              href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
-              aria-label="Go to Contact page"
-            >
-              get in touch
-            </Link>
-            .
-          </p>
-        </section>
+        <article className="space-y-12 max-w-3xl mx-auto md:mx-0">
+          {sections.map((section) => (
+            <section id={section.id} key={section.id}>
+              <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight text-gray-900">
+                {section.title}
+              </h2>
+              <div
+                className="prose prose-indigo text-lg leading-relaxed policy-text"
+                dangerouslySetInnerHTML={{
+                  __html: renderMarkdown(section.content),
+                }}
+              />
+            </section>
+          ))}
+        </article>
       </div>
     </section>
   );

--- a/app/privacy/privacy-policy.json
+++ b/app/privacy/privacy-policy.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "data-we-dont-collect",
+    "title": "Data We Don’t Collect",
+    "content": "- No personal information (name, address, email, etc.)\n- No file uploads or storage on our servers\n- No IP address logging\n- No behavioral analytics or usage tracking"
+  },
+  {
+    "id": "third-party-ads",
+    "title": "Advertising & Third-Party Services",
+    "content": "We display ads via third-party networks (e.g., Google Ads). Those providers may set their own cookies or trackers; please review their privacy policies. Gearizen does not share any personally identifiable data with advertisers."
+  },
+  {
+    "id": "cookies",
+    "title": "Cookies",
+    "content": "Gearizen itself does not use cookies. However, third-party ad networks may drop cookies under their own policies. You can manage those through your browser settings."
+  },
+  {
+    "id": "your-rights",
+    "title": "Your Rights",
+    "content": "Since we collect no personal data, there is nothing for you to access, modify, or delete. Your interactions remain private on your device."
+  },
+  {
+    "id": "policy-updates",
+    "title": "Policy Updates",
+    "content": "We may update this policy to reflect changes in our tools or applicable laws. Please revisit this page periodically to stay informed."
+  },
+  {
+    "id": "contact-us",
+    "title": "Contact Us",
+    "content": "If you have questions about this policy, please [get in touch](/contact)."
+  }
+]

--- a/docs/privacy-policy-guide.md
+++ b/docs/privacy-policy-guide.md
@@ -1,0 +1,22 @@
+# Privacy Policy Content & Style Guide
+
+This document explains how to update the Privacy Policy page content and maintain consistent styling across Gearizen.
+
+## Updating Content
+
+Policy sections are defined in `app/privacy/privacy-policy.json`. Each item has an `id`, `title`, and Markdown `content`. To add or modify a section:
+
+1. Edit `privacy-policy.json` and update the array.
+2. Keep `id` values URL friendly (lowercase and hyphenated).
+3. Use basic Markdown for formatting. Links should be relative when linking internally.
+4. Run `npm test` to ensure parsing and rendering tests still pass.
+
+## Styling Conventions
+
+- All policy text is rendered with Tailwind's `prose` class and additional styles from `globals.css`.
+- Use the `.policy-list` utility for bullet lists to keep spacing consistent.
+- Links automatically adopt brand colors via the `.policy-text a` rule.
+- Headings follow a consistent scale: `h2` for section titles.
+- The table of contents highlights the active section in indigo as the user scrolls.
+
+Follow these guidelines to keep the Privacy Policy readable, accessible, and visually consistent with the rest of the site.

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('toc links scroll correctly', async ({ page }) => {
+  await page.goto('/privacy');
+  await page.getByRole('link', { name: 'Data We Don\u2019t Collect' }).click();
+  await expect(page).toHaveURL(/#data-we-dont-collect/);
+  await expect(page.locator('#data-we-dont-collect')).toBeVisible();
+});
+
+test('mobile menu overlay toggles', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto('/privacy');
+  const toggle = page.getByLabel('Open menu');
+  await toggle.click();
+  await expect(page.locator('#mobile-menu')).toBeVisible();
+  await toggle.click();
+  await expect(page.locator('#mobile-menu')).not.toBeVisible();
+});

--- a/lib/privacyPolicy.ts
+++ b/lib/privacyPolicy.ts
@@ -1,0 +1,15 @@
+import policy from '../app/privacy/privacy-policy.json';
+
+export interface PolicySection {
+  id: string;
+  title: string;
+  content: string;
+}
+
+export function getPrivacyPolicySections(): PolicySection[] {
+  return (policy as PolicySection[]).map((section) => ({
+    id: section.id,
+    title: section.title,
+    content: section.content,
+  }));
+}


### PR DESCRIPTION
## Summary
- load privacy policy sections from JSON and render with Markdown
- add sticky table of contents with scroll spying
- update global styles for policy text
- include new metadata robots rule
- document privacy content editing
- add unit, integration and e2e tests for privacy policy

## Testing
- `npx jest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68728ba9e8648325abb15863b1e87e99