### PR TITLE
Refactor privacy policy with CMS data & TOC

### DIFF
--- a/__tests__/json-formatter-client.test.tsx
+++ b/__tests__/json-formatter-client.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import JsonFormatterClient from '../app/tools/json-formatter/json-formatter-client';
+import '@testing-library/jest-dom';
 
 describe('JsonFormatterClient', () => {
   test('shows formatted output on input', async () => {

--- a/__tests__/password-generator-client.test.tsx
+++ b/__tests__/password-generator-client.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PasswordGeneratorClient from '../app/tools/password-generator/password-generator-client';
+import '@testing-library/jest-dom';
 
 describe('PasswordGeneratorClient', () => {
   test('generates a new password when button is clicked', async () => {

--- a/__tests__/privacy-policy.test.tsx
+++ b/__tests__/privacy-policy.test.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { parsePolicy, getPolicySections } from '../lib/privacy-policy';
+import PrivacyClient from '../app/privacy/privacy-client';
+import policyData from '../docs/privacy-policy.json';
+import '@testing-library/jest-dom';
+
+// simple IntersectionObserver mock for jsdom
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+global.IntersectionObserver = MockIntersectionObserver;
+
+// Unit test for JSON parsing
+describe('parsePolicy', () => {
+  test('parses valid JSON', () => {
+    const sections = parsePolicy(policyData as unknown);
+    expect(sections.length).toBe(policyData.length);
+    expect(sections[0]).toHaveProperty('id');
+  });
+
+  test('throws on invalid data', () => {
+    expect(() => parsePolicy({} as any)).toThrow();
+  });
+});
+
+// Integration test to verify sections render
+
+describe('PrivacyClient rendering', () => {
+  test('renders all policy sections with headings', () => {
+    render(<PrivacyClient />);
+    const sections = getPolicySections();
+    sections.forEach(({ title, id }) => {
+      const heading = screen.getByRole('heading', { name: title });
+      expect(heading).toHaveAttribute('id', `${id}-heading`);
+    });
+  });
+});

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -17,7 +17,7 @@ export const metadata = {
     "privacy-focused tools",
   ],
   authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
-  robots: { index: true, follow: true },
+  robots: { index: true, follow: true, noarchive: true },
   alternates: { canonical: "https://gearizen.com/privacy" },
   openGraph: {
     title: "Privacy Policy | Gearizen",

--- a/app/privacy/privacy-client.tsx
+++ b/app/privacy/privacy-client.tsx
@@ -1,111 +1,89 @@
 // app/privacy/privacy-client.tsx
-
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { getPolicySections } from "@/lib/privacy-policy";
+import { renderMarkdown } from "@/lib/render-markdown";
+
+const sections = getPolicySections();
 
 export default function PrivacyClient() {
+  const [active, setActive] = useState<string>(sections[0]?.id);
+  const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "0px 0px -80% 0px" }
+    );
+    sections.forEach(({ id }) => {
+      const el = sectionRefs.current[id];
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <section
-      id="privacy-policy"
-      aria-labelledby="privacy-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
-    >
-      <h1
-        id="privacy-heading"
-        className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold mb-8 tracking-tight text-center"
+    <div className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900 flex flex-col lg:flex-row">
+      {/* Skip link */}
+      <a
+        href={`#${sections[0].id}`}
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 px-4 py-2 bg-indigo-600 text-white rounded-md"
       >
-        Privacy Policy
-      </h1>
+        Skip to policy content
+      </a>
 
-      <p className="mb-8 text-lg leading-relaxed max-w-3xl mx-auto">
-        At <strong>Gearizen</strong>, your privacy is our top priority. All of
-        our tools run <strong>100% client-side</strong>, meaning your data never
-        leaves your device—nothing is transmitted, stored, or tracked on our
-        servers.
-      </p>
-
-      <p className="mb-12 text-lg leading-relaxed max-w-3xl mx-auto">
-        You are never required to create an account or provide any personal
-        information. Feel free to use our password generators, JSON formatters,
-        text converters, QR code tools, and more—completely anonymously.
-      </p>
-
-      <div className="space-y-12 max-w-3xl mx-auto">
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Data We Don’t Collect
-          </h2>
-          <ul className="list-disc list-inside space-y-2 text-lg leading-relaxed">
-            <li>No personal information (name, address, email, etc.)</li>
-            <li>No file uploads or storage on our servers</li>
-            <li>No IP address logging</li>
-            <li>No behavioral analytics or usage tracking</li>
+      {/* TOC */}
+      <aside className="lg:w-1/4 lg:pr-8 mb-8 lg:mb-0" aria-label="Table of contents">
+        <nav className="lg:sticky lg:top-24">
+          <ul className="space-y-2 border-l border-gray-200 pl-4">
+            {sections.map(({ id, title }) => (
+              <li key={id} className="list-none">
+                <a
+                  href={`#${id}`}
+                  className={`block text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded ${active === id ? "text-indigo-600" : "text-gray-700 hover:text-gray-900"}`}
+                >
+                  {title}
+                </a>
+              </li>
+            ))}
           </ul>
-        </section>
+        </nav>
+      </aside>
 
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Advertising & Third-Party Services
-          </h2>
-          <p className="text-lg leading-relaxed">
-            We display ads via third-party networks (e.g., Google Ads). Those
-            providers may set their own cookies or trackers; please review their
-            privacy policies. Gearizen does not share any personally
-            identifiable data with advertisers.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Cookies
-          </h2>
-          <p className="text-lg leading-relaxed">
-            Gearizen itself does not use cookies. However, third-party ad
-            networks may drop cookies under their own policies. You can manage
-            those through your browser settings.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Your Rights
-          </h2>
-          <p className="text-lg leading-relaxed">
-            Since we collect no personal data, there is nothing for you to
-            access, modify, or delete. Your interactions remain private on your
-            device.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Policy Updates
-          </h2>
-          <p className="text-lg leading-relaxed">
-            We may update this policy to reflect changes in our tools or
-            applicable laws. Please revisit this page periodically to stay
-            informed.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Contact Us
-          </h2>
-          <p className="text-lg leading-relaxed">
-            If you have questions about this policy, please{" "}
-            <Link
-              href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
-              aria-label="Go to Contact page"
+      {/* Content */}
+      <div className="lg:flex-1 space-y-12" id="policy-start">
+        <h1 className="gradient-text text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight text-center mb-8">
+          Privacy Policy
+        </h1>
+        {sections.map(({ id, title, content }) => (
+          <section
+            key={id}
+            id={id}
+            ref={(el) => (sectionRefs.current[id] = el)}
+            aria-labelledby={`${id}-heading`}
+            className="max-w-3xl mx-auto"
+          >
+            <h2
+              id={`${id}-heading`}
+              className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight"
             >
-              get in touch
-            </Link>
-            .
-          </p>
-        </section>
+              {title}
+            </h2>
+            <div
+              className="prose prose-indigo max-w-none text-lg leading-relaxed"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
+            />
+          </section>
+        ))}
       </div>
-    </section>
+    </div>
   );
 }

--- a/docs/privacy-policy-guide.md
+++ b/docs/privacy-policy-guide.md
@@ -1,0 +1,26 @@
+# Privacy Policy Content & Style Guide
+
+This guide outlines how to update the privacy policy sections and keep the page consistent with Gearizen's design language.
+
+## Editing Policy Content
+
+- All policy sections are stored in `docs/privacy-policy.json`.
+- Each entry has an `id`, `title`, and Markdown `content` field.
+- Use simple Markdown for formatting: lists, **bold text**, and [links](/contact).
+- Keep language concise and focused on client-side privacy.
+- Ensure IDs are lowercase with hyphens so links remain stable.
+
+## Layout & Styling
+
+- The policy page displays a sticky table of contents on desktop.
+- Section headings use `h2` elements with IDs from the JSON file.
+- Rich text is rendered using the shared `renderMarkdown` utility and styled with Tailwind's `prose` classes.
+- Avoid inline styles or additional classes—let the utility classes handle spacing and typography.
+
+## Accessibility Tips
+
+- Include descriptive link text and avoid "click here" phrases.
+- Verify color contrast when adjusting colors.
+- Test keyboard navigation through the TOC and policy sections.
+
+Following these guidelines ensures the privacy policy stays maintainable and accessible while matching the rest of the Gearizen platform.

--- a/docs/privacy-policy.json
+++ b/docs/privacy-policy.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "overview",
+    "title": "Overview",
+    "content": "At **Gearizen**, all tools run 100% client-side. Your data never leaves your device."
+  },
+  {
+    "id": "data-we-dont-collect",
+    "title": "Data We Don’t Collect",
+    "content": "- Personal information (name, address, email)\n- File uploads or server storage\n- IP address logging\n- Usage tracking or analytics"
+  },
+  {
+    "id": "third-party-ads",
+    "title": "Third-Party Ads",
+    "content": "We display ads via third-party networks like Google Ads. These providers may use cookies or device identifiers as described in their own policies. **Gearizen does not share any personal data** with advertisers."
+  },
+  {
+    "id": "cookies",
+    "title": "Cookies",
+    "content": "Gearizen itself does not set any cookies. Third-party ad networks may set cookies which you can manage through your browser settings."
+  },
+  {
+    "id": "your-rights",
+    "title": "Your Rights",
+    "content": "Since we collect no personal data, there is nothing for you to access, modify or delete. Your interactions remain on your device."
+  },
+  {
+    "id": "policy-updates",
+    "title": "Policy Updates",
+    "content": "We may update this policy to reflect changes in our tools or legal requirements. Please check back periodically."
+  },
+  {
+    "id": "contact-us",
+    "title": "Contact Us",
+    "content": "If you have any questions, please [contact us](/contact)."
+  }
+]

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// Verify TOC link scrolls and mobile menu overlay
+
+test('privacy policy TOC navigation', async ({ page }) => {
+  await page.goto('/privacy');
+  const link = page.getByRole('link', { name: 'Data We Don\u2019t Collect' });
+  await link.click();
+  await expect(page).toHaveURL(/#data-we-dont-collect/);
+  await expect(page.locator('#data-we-dont-collect')).toBeInViewport();
+});
+
+test('mobile menu overlay toggles on privacy page', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/privacy');
+  await page.getByRole('button', { name: /open menu/i }).click();
+  await expect(page.locator('#mobile-menu')).toBeVisible();
+  await page.getByRole('button', { name: /close menu/i }).click();
+  await expect(page.locator('#mobile-menu')).not.toBeVisible();
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,11 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts-esm',
   testEnvironment: 'node',
-  testMatch: ['**/*.test.ts'],
+  testMatch: ['**/*.test.ts', '**/*policy.test.tsx'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@/(.*)$': '<rootDir>/$1',
   },
   transformIgnorePatterns: [
     '/node_modules/(?!(marked)/)'

--- a/lib/privacy-policy.ts
+++ b/lib/privacy-policy.ts
@@ -1,0 +1,34 @@
+import data from '../docs/privacy-policy.json';
+
+export interface PolicySection {
+  id: string;
+  title: string;
+  content: string;
+}
+
+/**
+ * Validates and returns privacy policy sections from JSON.
+ */
+export function parsePolicy(json: unknown): PolicySection[] {
+  if (!Array.isArray(json)) {
+    throw new Error('Invalid policy data');
+  }
+  return json.map((item) => {
+    if (
+      !item ||
+      typeof item.id !== 'string' ||
+      typeof item.title !== 'string' ||
+      typeof item.content !== 'string'
+    ) {
+      throw new Error('Invalid policy section');
+    }
+    return { id: item.id, title: item.title, content: item.content };
+  });
+}
+
+/**
+ * Returns parsed policy sections from the bundled JSON file.
+ */
+export function getPolicySections(): PolicySection[] {
+  return parsePolicy(data as unknown);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-config-next": "15.3.5",
         "husky": "^8.0.0",
         "jest": "^30.0.4",
+        "jest-environment-jsdom": "^30.0.4",
         "lint-staged": "^16.1.2",
         "next-sitemap": "^4.2.3",
         "prettier": "^3.0.0",
@@ -1813,6 +1814,34 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.0.4.tgz",
+      "integrity": "sha512-pUKfqgr5Nki9kZ/3iV+ubDsvtPq0a0oNL6zqkKLM1tPQI8FBJeuWskvW1kzc5pOvqlgpzumYZveJ4bxhANY0hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.0.4",
+        "@jest/fake-timers": "30.0.4",
+        "@jest/types": "30.0.1",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.0.2",
+        "jest-util": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jest/expect": {
       "version": "30.0.4",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.0.4.tgz",
@@ -3215,6 +3244,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3326,6 +3367,13 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -8012,6 +8060,31 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.0.4.tgz",
+      "integrity": "sha512-9WmS3oyCLFgs6DUJSoMpVb+AbH62Y2Xecw3XClbRgj6/Z+VjNeSLjrhBgVvTZ40njZTWeDHv8unp+6M/z8ADDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.0.4",
+        "@jest/environment-jsdom-abstract": "30.0.4",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-next": "15.3.5",
     "husky": "^8.0.0",
     "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
     "lint-staged": "^16.1.2",
     "next-sitemap": "^4.2.3",
     "prettier": "^3.0.0",


### PR DESCRIPTION
## Summary
- drive privacy policy sections from `docs/privacy-policy.json`
- render sections dynamically with sticky table of contents
- add `PrivacyPolicy` utilities and tests
- document content rules in `docs/privacy-policy-guide.md`
- add Playwright e2e test for policy navigation

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68728ba9e8648325abb15863b1e87e99