### PR TITLE
Refactor Privacy Policy page

### DIFF
--- a/__tests__/privacy-client.test.tsx
+++ b/__tests__/privacy-client.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import PrivacyClient from '../app/privacy/privacy-client';
+import { getPrivacySections } from '../lib/privacy';
+
+describe('PrivacyClient', () => {
+  test('renders headings for each section', () => {
+    render(<PrivacyClient />);
+    const sections = getPrivacySections().filter(s => s.id !== 'intro');
+    sections.forEach(sec => {
+      const heading = screen.getByRole('heading', { name: sec.title });
+      expect(heading).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/privacy.test.ts
+++ b/__tests__/privacy.test.ts
@@ -1,0 +1,21 @@
+import { getPrivacySections } from '../lib/privacy';
+import { renderMarkdown } from '../lib/render-markdown';
+
+describe('privacy policy data', () => {
+  test('parses sections from JSON', () => {
+    const sections = getPrivacySections();
+    expect(Array.isArray(sections)).toBe(true);
+    expect(sections.length).toBeGreaterThan(0);
+    for (const sec of sections) {
+      expect(typeof sec.id).toBe('string');
+      expect(typeof sec.title).toBe('string');
+      expect(typeof sec.body).toBe('string');
+    }
+  });
+
+  test('renders markdown to html', () => {
+    const section = getPrivacySections()[0];
+    const html = renderMarkdown(section.body);
+    expect(html).toMatch(/<p|<ul/);
+  });
+});

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -18,6 +18,7 @@ export const metadata = {
   ],
   authors: [{ name: "Gearizen Team", url: "https://gearizen.com/about" }],
   robots: { index: true, follow: true },
+  other: { robots: 'noarchive' },
   alternates: { canonical: "https://gearizen.com/privacy" },
   openGraph: {
     title: "Privacy Policy | Gearizen",

--- a/app/privacy/privacy-client.tsx
+++ b/app/privacy/privacy-client.tsx
@@ -2,14 +2,39 @@
 
 "use client";
 
-import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getPrivacySections } from "@/lib/privacy";
+import { renderMarkdown } from "@/lib/render-markdown";
+
+const sections = getPrivacySections();
 
 export default function PrivacyClient() {
+  const [activeId, setActiveId] = useState<string>();
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "0px 0px -60% 0px" }
+    );
+
+    sections.forEach((s) => {
+      const el = document.getElementById(s.id);
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <section
       id="privacy-policy"
       aria-labelledby="privacy-heading"
-      className="container-responsive py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
+      className="py-20 text-gray-900 antialiased selection:bg-indigo-200 selection:text-indigo-900"
     >
       <h1
         id="privacy-heading"
@@ -18,93 +43,63 @@ export default function PrivacyClient() {
         Privacy Policy
       </h1>
 
-      <p className="mb-8 text-lg leading-relaxed max-w-3xl mx-auto">
-        At <strong>Gearizen</strong>, your privacy is our top priority. All of
-        our tools run <strong>100% client-side</strong>, meaning your data never
-        leaves your device—nothing is transmitted, stored, or tracked on our
-        servers.
-      </p>
+      <a
+        href="#toc"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 p-2 bg-indigo-600 text-white rounded"
+      >
+        Skip to policy sections
+      </a>
 
-      <p className="mb-12 text-lg leading-relaxed max-w-3xl mx-auto">
-        You are never required to create an account or provide any personal
-        information. Feel free to use our password generators, JSON formatters,
-        text converters, QR code tools, and more—completely anonymously.
-      </p>
-
-      <div className="space-y-12 max-w-3xl mx-auto">
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Data We Don’t Collect
-          </h2>
-          <ul className="list-disc list-inside space-y-2 text-lg leading-relaxed">
-            <li>No personal information (name, address, email, etc.)</li>
-            <li>No file uploads or storage on our servers</li>
-            <li>No IP address logging</li>
-            <li>No behavioral analytics or usage tracking</li>
+      <div className="lg:flex lg:space-x-12 container-responsive">
+        <nav
+          id="toc"
+          aria-label="Table of contents"
+          className="hidden lg:block lg:w-64 flex-shrink-0 sticky top-24 self-start"
+        >
+          <ul className="space-y-2 text-sm leading-6">
+            {sections
+              .filter((s) => s.id !== "intro")
+              .map((section) => (
+                <li key={section.id} className="list-none">
+                  <a
+                    href={`#${section.id}`}
+                    className={`block px-2 py-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                      activeId === section.id
+                        ? "text-indigo-600 font-semibold"
+                        : "text-gray-700 hover:text-gray-900"
+                    }`}
+                  >
+                    {section.title}
+                  </a>
+                </li>
+              ))}
           </ul>
-        </section>
+        </nav>
 
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Advertising & Third-Party Services
-          </h2>
-          <p className="text-lg leading-relaxed">
-            We display ads via third-party networks (e.g., Google Ads). Those
-            providers may set their own cookies or trackers; please review their
-            privacy policies. Gearizen does not share any personally
-            identifiable data with advertisers.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Cookies
-          </h2>
-          <p className="text-lg leading-relaxed">
-            Gearizen itself does not use cookies. However, third-party ad
-            networks may drop cookies under their own policies. You can manage
-            those through your browser settings.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Your Rights
-          </h2>
-          <p className="text-lg leading-relaxed">
-            Since we collect no personal data, there is nothing for you to
-            access, modify, or delete. Your interactions remain private on your
-            device.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Policy Updates
-          </h2>
-          <p className="text-lg leading-relaxed">
-            We may update this policy to reflect changes in our tools or
-            applicable laws. Please revisit this page periodically to stay
-            informed.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight">
-            Contact Us
-          </h2>
-          <p className="text-lg leading-relaxed">
-            If you have questions about this policy, please{" "}
-            <Link
-              href="/contact"
-              className="text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded transition-colors"
-              aria-label="Go to Contact page"
+        <div className="flex-1 space-y-12 max-w-3xl mx-auto">
+          {sections.map((section) => (
+            <section
+              key={section.id}
+              id={section.id}
+              aria-labelledby={`${section.id}-heading`}
             >
-              get in touch
-            </Link>
-            .
-          </p>
-        </section>
+              {section.id !== "intro" && (
+                <h2
+                  id={`${section.id}-heading`}
+                  className="text-2xl sm:text-3xl font-semibold mb-4 tracking-tight"
+                >
+                  {section.title}
+                </h2>
+              )}
+              <div
+                className="prose prose-gray text-lg leading-relaxed"
+                dangerouslySetInnerHTML={{
+                  __html: renderMarkdown(section.body),
+                }}
+              />
+            </section>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/docs/privacy-style-guide.md
+++ b/docs/privacy-style-guide.md
@@ -1,0 +1,25 @@
+# Privacy Policy Content & Style Guide
+
+This document outlines how Gearizen structures and styles the Privacy Policy page.
+
+## JSON Schema
+Each section of the policy is stored in `lib/privacy-sections.json` using the following fields:
+
+```json
+{
+  "id": "string",             // unique section anchor
+  "title": "string",          // heading text
+  "body": "markdown string"   // content in Markdown
+}
+```
+
+Markdown supports **bold text**, lists, and [links](/contact) which are sanitized before rendering.
+
+## Layout Guidelines
+- Mobile: single column, large text with relaxed line height.
+- Desktop: content width constrained to `max-w-3xl` with a sticky sidebar table of contents (`lg:w-64`).
+- Use Tailwind utility classes for spacing and typography. Headings use the `gradient-text` class and body copy uses `prose` styles.
+- Links and legal headings use brand indigo colors for clarity.
+- Lists use standard disc bullets.
+
+Follow this guide when updating policy content or adjusting styles to maintain a consistent, accessible design.

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('toc links scroll to section and mobile menu overlay works', async ({ page }) => {
+  await page.goto('/privacy');
+  const tocLink = page.getByRole('link', { name: 'Data We Don\u2019t Collect' });
+  await tocLink.click();
+  await expect(page).toHaveURL(/#data-we-dont-collect/);
+  await expect(page.locator('#data-we-dont-collect')).toBeVisible();
+
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.getByRole('button', { name: 'Open menu' }).click();
+  await expect(page.locator('#mobile-menu')).toBeVisible();
+});

--- a/lib/privacy-sections.json
+++ b/lib/privacy-sections.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "intro",
+    "title": "Privacy Policy",
+    "body": "At **Gearizen**, your privacy is our top priority. All of our tools run **100% client-side**, meaning your data never leaves your device—nothing is transmitted, stored, or tracked on our servers.\n\nYou are never required to create an account or provide any personal information. Feel free to use our password generators, JSON formatters, text converters, QR code tools, and more—completely anonymously."
+  },
+  {
+    "id": "data-we-dont-collect",
+    "title": "Data We Don\u2019t Collect",
+    "body": "- No personal information (name, address, email, etc.)\n- No file uploads or storage on our servers\n- No IP address logging\n- No behavioral analytics or usage tracking"
+  },
+  {
+    "id": "third-party-services",
+    "title": "Advertising & Third-Party Services",
+    "body": "We display ads via third-party networks (e.g., Google Ads). Those providers may set their own cookies or trackers; please review their privacy policies. Gearizen does not share any personally identifiable data with advertisers."
+  },
+  {
+    "id": "cookies",
+    "title": "Cookies",
+    "body": "Gearizen itself does not use cookies. However, third-party ad networks may drop cookies under their own policies. You can manage those through your browser settings."
+  },
+  {
+    "id": "your-rights",
+    "title": "Your Rights",
+    "body": "Since we collect no personal data, there is nothing for you to access, modify, or delete. Your interactions remain private on your device."
+  },
+  {
+    "id": "policy-updates",
+    "title": "Policy Updates",
+    "body": "We may update this policy to reflect changes in our tools or applicable laws. Please revisit this page periodically to stay informed."
+  },
+  {
+    "id": "contact",
+    "title": "Contact Us",
+    "body": "If you have questions about this policy, please [get in touch](/contact)."
+  }
+]

--- a/lib/privacy.ts
+++ b/lib/privacy.ts
@@ -1,0 +1,12 @@
+import sections from './privacy-sections.json';
+
+export interface PrivacySection {
+  id: string;
+  title: string;
+  body: string;
+}
+
+/** Returns structured privacy policy sections loaded from JSON. */
+export function getPrivacySections(): PrivacySection[] {
+  return sections as PrivacySection[];
+}


### PR DESCRIPTION
## Summary
- drive Privacy Policy sections from JSON data
- render sections as Markdown with sticky table of contents
- add noarchive robots meta
- document content structure in a style guide
- test JSON parsing and MDX-like rendering
- test PrivacyClient rendering and TOC behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68728ba9e8648325abb15863b1e87e99