### PR TITLE
Enhance color palette generator

### DIFF
--- a/__tests__/color-palette-client.test.tsx
+++ b/__tests__/color-palette-client.test.tsx
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ColorPaletteGeneratorClient from "../app/tools/color-palette-generator/color-palette-generator-client";
+
+function getSwatches() {
+  return screen.getAllByRole("button", { name: /copy/i });
+}
+
+describe("ColorPaletteGeneratorClient", () => {
+  test("updates palette count via slider", () => {
+    render(<ColorPaletteGeneratorClient />);
+    const slider = screen.getByLabelText(/colors/i);
+    fireEvent.change(slider, { target: { value: "4" } });
+    expect(getSwatches().length).toBe(4);
+  });
+
+  test("download JSON triggers blob URL", async () => {
+    const user = userEvent.setup();
+    const createSpy = jest
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:1");
+    render(<ColorPaletteGeneratorClient />);
+    const button = screen.getByRole("button", { name: /download json/i });
+    await user.click(button);
+    expect(createSpy).toHaveBeenCalled();
+    createSpy.mockRestore();
+  });
+});

--- a/__tests__/color-palette.test.ts
+++ b/__tests__/color-palette.test.ts
@@ -1,15 +1,30 @@
 import { generatePalette } from '../lib/color-palette';
 
 describe('generatePalette', () => {
-  test('complementary palette', () => {
-    expect(generatePalette('#ff0000', 'complementary')).toEqual(['#ff0000', '#00ffff']);
+  test('complementary palette base cases', () => {
+    expect(generatePalette('#ff0000', 'complementary', 2)).toEqual([
+      '#ff0000',
+      '#00ffff',
+    ]);
   });
 
-  test('triadic palette', () => {
-    expect(generatePalette('#ff0000', 'triadic')).toEqual(['#ff0000', '#00ff00', '#0000ff']);
+  test('triadic palette base cases', () => {
+    expect(generatePalette('#ff0000', 'triadic', 3)).toEqual([
+      '#ff0000',
+      '#00ff00',
+      '#0000ff',
+    ]);
   });
 
-  test('analogous count', () => {
-    expect(generatePalette('#ff0000', 'analogous', 5)).toHaveLength(5);
+  test('tetradic palette count', () => {
+    expect(generatePalette('#ff0000', 'tetradic', 4)).toHaveLength(4);
+  });
+
+  test('monochromatic palette count', () => {
+    expect(generatePalette('#ff0000', 'monochromatic', 6)).toHaveLength(6);
+  });
+
+  test('analogous variable count', () => {
+    expect(generatePalette('#ff0000', 'analogous', 7)).toHaveLength(7);
   });
 });

--- a/app/tools/color-palette-generator/page.tsx
+++ b/app/tools/color-palette-generator/page.tsx
@@ -5,7 +5,8 @@ import BreadcrumbJsonLd from '@/app/components/BreadcrumbJsonLd';
 export const metadata: Metadata = {
   metadataBase: new URL('https://gearizen.com'),
   title: 'Color Palette Generator',
-  description: 'Create harmonious color palettes from any base color directly in your browser.',
+  description:
+    'Create harmonious color palettes from any base color directly in your browser. Choose harmony rules and export as JSON or ASE.',
   keywords: ['color palette', 'palette generator', 'color scheme', 'design tool', 'Gearizen tools'],
   authors: [{ name: 'Gearizen Team', url: 'https://gearizen.com/about' }],
   robots: { index: true, follow: true },

--- a/e2e/color-palette-generator.spec.ts
+++ b/e2e/color-palette-generator.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test("generate and download palette", async ({ page, browserName }) => {
+  await page.goto("/tools/color-palette-generator");
+  await page.getByRole("radio", { name: "Tetradic" }).click();
+  const slider = page.getByLabel("Colors:");
+  await slider.evaluate((el: HTMLInputElement) => {
+    el.value = "4";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await expect(page.locator("button", { hasText: "Copy" })).toHaveCount(4);
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: /download json/i }).click(),
+  ]);
+  expect(download.suggestedFilename()).toMatch(/\.json$/);
+});

--- a/lib/color-palette.ts
+++ b/lib/color-palette.ts
@@ -1,6 +1,11 @@
 import { hexToRgb, rgbToHex, rgbToHsl, hslToRgb } from './color-conversion';
 
-export type PaletteScheme = 'analogous' | 'complementary' | 'triadic';
+export type PaletteScheme =
+  | 'analogous'
+  | 'complementary'
+  | 'triadic'
+  | 'tetradic'
+  | 'monochromatic';
 
 /**
  * Generate a simple color palette from a base HEX color.
@@ -17,17 +22,104 @@ export function generatePalette(
   if (!rgb) throw new Error('Invalid hex color');
   const { h, s, l } = rgbToHsl(rgb);
   const wrap = (val: number) => ((val % 360) + 360) % 360;
-  const toHex = (hue: number) => rgbToHex(hslToRgb({ h: wrap(hue), s, l }));
+  const toHex = (hue: number, sat = s, light = l) =>
+    rgbToHex(hslToRgb({ h: wrap(hue), s: sat, l: light }));
+
+  const buildOffsets = (offsets: number[]): number[] => {
+    const out = [...offsets];
+    let delta = 30;
+    while (out.length < count) {
+      for (const baseOff of offsets) {
+        if (out.length >= count) break;
+        out.push(baseOff + delta);
+        if (out.length >= count) break;
+        out.push(baseOff - delta);
+      }
+      delta += 30;
+    }
+    return out.slice(0, count);
+  };
 
   switch (scheme) {
     case 'complementary':
-      return [base, toHex(h + 180)];
+      return buildOffsets([0, 180]).map((o) => toHex(h + o));
     case 'triadic':
-      return [base, toHex(h + 120), toHex(h + 240)];
+      return buildOffsets([0, 120, 240]).map((o) => toHex(h + o));
+    case 'tetradic':
+      return buildOffsets([0, 90, 180, 270]).map((o) => toHex(h + o));
+    case 'monochromatic': {
+      const start = Math.max(0, l - 40);
+      const end = Math.min(100, l + 40);
+      return Array.from({ length: count }, (_, i) => {
+        const t = count === 1 ? 0 : i / (count - 1);
+        const light = start + (end - start) * t;
+        return toHex(h, s, light);
+      });
+    }
+    case 'analogous':
     default: {
       const half = Math.floor(count / 2);
       const step = 30;
       return Array.from({ length: count }, (_, i) => toHex(h + (i - half) * step));
     }
   }
+}
+
+export function paletteToJson(palette: string[]): string {
+  return JSON.stringify(palette, null, 2);
+}
+
+export function paletteToAse(palette: string[]): Uint8Array {
+  const blocks: Uint8Array[] = [];
+  const te = new TextEncoder();
+
+  palette.forEach((hex, idx) => {
+    const rgb = hexToRgb(hex);
+    if (!rgb) return;
+    const name = `Color ${idx + 1}`;
+    const nameBuf = new Uint8Array(2 + (name.length + 1) * 2);
+    const nameView = new DataView(nameBuf.buffer);
+    nameView.setUint16(0, name.length + 1, false);
+    for (let i = 0; i < name.length; i++) {
+      nameView.setUint16(2 + i * 2, name.charCodeAt(i), false);
+    }
+    nameView.setUint16(2 + name.length * 2, 0, false);
+
+    const colorBuf = new Uint8Array(4 + 12 + 2);
+    colorBuf.set(te.encode('RGB '), 0);
+    const colorView = new DataView(colorBuf.buffer);
+    colorView.setFloat32(4, rgb.r / 255, false);
+    colorView.setFloat32(8, rgb.g / 255, false);
+    colorView.setFloat32(12, rgb.b / 255, false);
+    colorView.setUint16(16, 0, false);
+
+    const blockLen = nameBuf.length + colorBuf.length;
+    const block = new Uint8Array(2 + 4 + blockLen);
+    const blockView = new DataView(block.buffer);
+    blockView.setUint16(0, 0x0001, false);
+    blockView.setUint32(2, blockLen, false);
+    block.set(nameBuf, 6);
+    block.set(colorBuf, 6 + nameBuf.length);
+    blocks.push(block);
+  });
+
+  const header = new Uint8Array(12);
+  header[0] = 0x41;
+  header[1] = 0x53;
+  header[2] = 0x45;
+  header[3] = 0x46;
+  const hv = new DataView(header.buffer);
+  hv.setUint16(4, 1, false);
+  hv.setUint16(6, 0, false);
+  hv.setUint32(8, blocks.length, false);
+
+  const total = header.length + blocks.reduce((t, b) => t + b.length, 0);
+  const out = new Uint8Array(total);
+  out.set(header, 0);
+  let offset = header.length;
+  for (const b of blocks) {
+    out.set(b, offset);
+    offset += b.length;
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary
- support tetradic and monochromatic schemes
- allow palettes up to 10 colors with a range input
- show HEX/RGB/HSL on hover with copy button
- export palettes as JSON or ASE
- test palette algorithms and UI
- add e2e check for palette generation

## Testing
- `npm test`
- `npm run test:e2e` *(fails: 5 failed, 40 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68729a18ed9c832589ee930d75e4e791