### PR TITLE
Enhance Color Converter tool

### DIFF
--- a/__tests__/color-conversion.test.ts
+++ b/__tests__/color-conversion.test.ts
@@ -1,25 +1,49 @@
-import { convertColor } from '../lib/color-conversion';
+/** @jest-environment node */
+import {
+  hexToRgba,
+  rgbaToHex,
+  rgbaToHsla,
+  hslaToRgba,
+  rgbaToCmyk,
+  cmykToRgba,
+  convertColor,
+} from '../lib/color-conversion';
+
+describe('color conversion formulas', () => {
+  test('hex to rgba and back', () => {
+    const rgba = hexToRgba('#ff000080');
+    expect(rgba?.r).toBe(255);
+    expect(rgba?.g).toBe(0);
+    expect(rgba?.b).toBe(0);
+    expect(rgba?.a ?? 0).toBeCloseTo(0.5, 2);
+    expect(rgba && rgbaToHex(rgba)).toBe('#ff000080');
+  });
+
+  test('rgba to hsla round trip', () => {
+    const hsla = rgbaToHsla({ r: 0, g: 255, b: 0, a: 1 });
+    const rgba = hslaToRgba(hsla);
+    expect(rgba).toEqual({ r: 0, g: 255, b: 0, a: 1 });
+  });
+
+  test('rgba to cmyk round trip', () => {
+    const cmyk = rgbaToCmyk({ r: 0, g: 0, b: 255, a: 1 });
+    const rgba = cmykToRgba(cmyk);
+    expect(rgba).toEqual({ r: 0, g: 0, b: 255, a: 1 });
+  });
+});
 
 describe('convertColor', () => {
-  test('converts hex to rgb and hsl', () => {
-    const result = convertColor('#ff0000');
-    expect(result).toEqual({
+  test('handles multiple formats', () => {
+    const res = convertColor('cmyk(0%, 100%, 100%, 0%)');
+    expect(res).toEqual({
       hex: '#ff0000',
       rgb: 'rgb(255, 0, 0)',
       hsl: 'hsl(0, 100%, 50%)',
+      cmyk: 'cmyk(0%, 100%, 100%, 0%)',
     });
   });
 
-  test('converts rgb to hex and hsl', () => {
-    const result = convertColor('rgb(0, 255, 0)');
-    expect(result).toEqual({
-      hex: '#00ff00',
-      rgb: 'rgb(0, 255, 0)',
-      hsl: 'hsl(120, 100%, 50%)',
-    });
-  });
-
-  test('returns null for invalid input', () => {
-    expect(convertColor('not-a-color')).toBeNull();
+  test('returns null on invalid', () => {
+    expect(convertColor('invalid')).toBeNull();
   });
 });

--- a/__tests__/color-converter-client.test.tsx
+++ b/__tests__/color-converter-client.test.tsx
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ColorConverterClient from '../app/tools/color-converter/color-converter-client';
+
+describe('ColorConverterClient', () => {
+  test('updates fields when hex changes', async () => {
+    const user = userEvent.setup();
+    render(<ColorConverterClient />);
+    const hex = screen.getByLabelText('HEX');
+    await user.clear(hex);
+    await user.type(hex, '#00ff00');
+    expect(screen.getByLabelText('RGB(A)')).toHaveValue('rgb(0, 255, 0)');
+    expect(screen.getByLabelText('HSL(A)')).toHaveValue('hsl(120, 100%, 50%)');
+    expect(screen.getByLabelText('CMYK')).toHaveValue('cmyk(100%, 0%, 100%, 0%)');
+  });
+
+  test('two-way binding from rgb', async () => {
+    const user = userEvent.setup();
+    render(<ColorConverterClient />);
+    const rgb = screen.getByLabelText('RGB(A)');
+    await user.clear(rgb);
+    await user.type(rgb, 'rgb(0, 0, 255)');
+    expect(screen.getByLabelText('HEX')).toHaveValue('#0000ff');
+  });
+});

--- a/app/tools/color-converter/color-converter-client.tsx
+++ b/app/tools/color-converter/color-converter-client.tsx
@@ -1,8 +1,9 @@
 // app/tools/color-converter/color-converter-client.tsx
 "use client";
 
-import { useState, ChangeEvent } from "react";
+import { useState, ChangeEvent, useMemo } from "react";
 import { convertColor } from "@/lib/color-conversion";
+import { generatePalette } from "@/lib/color-palette";
 import Input from "@/components/Input";
 
 export default function ColorConverterClient() {
@@ -10,25 +11,59 @@ export default function ColorConverterClient() {
   const [hex, setHex] = useState("#ff0000");
   const [rgb, setRgb] = useState("rgb(255, 0, 0)");
   const [hsl, setHsl] = useState("hsl(0, 100%, 50%)");
+  const [cmyk, setCmyk] = useState("cmyk(0%, 100%, 100%, 0%)");
   const [error, setError] = useState<string | null>(null);
 
-  const update = (value: string) => {
+  const updateAll = (value: string) => {
     const res = convertColor(value);
     if (res) {
       setHex(res.hex);
       setRgb(res.rgb);
       setHsl(res.hsl);
+      setCmyk(res.cmyk);
       setError(null);
-    } else {
-      setError("Invalid color format");
+      return true;
     }
+    setError("Invalid color format");
+    return false;
   };
 
   const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
     setInput(val);
-    update(val);
+    updateAll(val);
   };
+
+  const handleHex = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setHex(val);
+    if (updateAll(val)) setInput(val);
+  };
+
+  const handleRgb = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setRgb(val);
+    if (updateAll(val)) setInput(val);
+  };
+
+  const handleHsl = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setHsl(val);
+    if (updateAll(val)) setInput(val);
+  };
+
+  const handleCmyk = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setCmyk(val);
+    if (updateAll(val)) setInput(val);
+  };
+
+  const swatchColors = useMemo(() => {
+    const comp = generatePalette(hex, "complementary")[1];
+    const tri = generatePalette(hex, "triadic").slice(1);
+    const ana = generatePalette(hex, "analogous", 3).slice(1);
+    return [hex, comp, ...tri, ...ana];
+  }, [hex]);
 
   return (
     <section
@@ -43,37 +78,62 @@ export default function ColorConverterClient() {
         Color Converter
       </h1>
       <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
-        Enter a color in HEX, RGB, or HSL format to convert between representations.
+        Enter any HEX, RGB(A), HSL(A), or CMYK value to convert between color spaces.
       </p>
-      <div className="max-w-md mx-auto space-y-6">
-        <Input
-          value={input}
-          onChange={handleInput}
-          aria-label="Color input"
-          placeholder="#ff0000 or rgb(255,0,0) or hsl(0,100%,50%)"
-        />
+      <div className="max-w-xl mx-auto space-y-6">
+        <div>
+          <label htmlFor="color-input" className="block mb-1 font-medium text-gray-800">
+            Color Input
+          </label>
+          <Input
+            id="color-input"
+            value={input}
+            onChange={handleInput}
+            aria-label="Color input"
+            placeholder="#ff0000 or rgb(255,0,0)"
+          />
+        </div>
+
         {error && <p role="alert" className="text-red-600 text-sm">{error}</p>}
-        {!error && (
-          <div className="space-y-4">
-            <div className="flex items-center space-x-2">
-              <span className="w-4 font-medium">HEX</span>
-              <Input value={hex} readOnly className="flex-grow" />
-            </div>
-            <div className="flex items-center space-x-2">
-              <span className="w-4 font-medium">RGB</span>
-              <Input value={rgb} readOnly className="flex-grow" />
-            </div>
-            <div className="flex items-center space-x-2">
-              <span className="w-4 font-medium">HSL</span>
-              <Input value={hsl} readOnly className="flex-grow" />
-            </div>
-            <div
-              className="h-12 rounded" 
-              style={{ backgroundColor: hex }}
-              aria-label="Color preview"
-            />
+
+        <div className="flex flex-col md:flex-row md:items-end gap-4">
+          <div className="flex-1">
+            <label htmlFor="hex" className="block mb-1 font-medium text-gray-800">
+              HEX
+            </label>
+            <Input id="hex" value={hex} onChange={handleHex} aria-label="HEX" />
           </div>
-        )}
+          <div className="flex-1">
+            <label htmlFor="rgb" className="block mb-1 font-medium text-gray-800">
+              RGB(A)
+            </label>
+            <Input id="rgb" value={rgb} onChange={handleRgb} aria-label="RGB(A)" />
+          </div>
+          <div className="flex-1">
+            <label htmlFor="hsl" className="block mb-1 font-medium text-gray-800">
+              HSL(A)
+            </label>
+            <Input id="hsl" value={hsl} onChange={handleHsl} aria-label="HSL(A)" />
+          </div>
+          <div className="flex-1">
+            <label htmlFor="cmyk" className="block mb-1 font-medium text-gray-800">
+              CMYK
+            </label>
+            <Input id="cmyk" value={cmyk} onChange={handleCmyk} aria-label="CMYK" />
+          </div>
+        </div>
+
+        <div
+          className="relative group h-12 rounded"
+          style={{ backgroundColor: hex }}
+          aria-label="Color preview"
+        >
+          <div className="absolute inset-0 hidden group-hover:flex items-center justify-center gap-1 bg-white/80 rounded p-1">
+            {swatchColors.map((c) => (
+              <span key={c} className="w-5 h-5 rounded" style={{ backgroundColor: c }} />
+            ))}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/app/tools/color-converter/page.tsx
+++ b/app/tools/color-converter/page.tsx
@@ -7,11 +7,12 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://gearizen.com"),
   title: "Color Converter",
   description:
-    "Translate colors between HEX, RGB, and HSL instantly. 100% client-side with a live preview.",
+    "Translate colors between HEX, RGB(A), HSL(A), and CMYK instantly. 100% client-side with a live preview.",
   keywords: [
     "color converter",
     "hex to rgb",
     "rgb to hsl",
+    "cmyk to rgb",
     "color tools",
     "Gearizen color",
   ],
@@ -21,7 +22,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Color Converter | Gearizen",
     description:
-      "Convert any color code between HEX, RGB, and HSL formats with instant preview.",
+      "Convert any color code between HEX, RGB(A), HSL(A), and CMYK with instant preview.",
     url: "https://gearizen.com/tools/color-converter",
     siteName: "Gearizen",
     locale: "en_US",
@@ -34,7 +35,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Color Converter | Gearizen",
     description:
-      "Quickly convert colors between HEX, RGB, and HSL using Gearizen’s browser-based tool.",
+      "Quickly convert colors between HEX, RGB(A), HSL(A), and CMYK using Gearizen’s browser-based tool.",
     creator: "@gearizen",
     images: ["/og-placeholder.svg"],
   },

--- a/e2e/color-converter.spec.ts
+++ b/e2e/color-converter.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('color converter round trip', async ({ page }) => {
+  await page.goto('/tools/color-converter');
+  await page.getByLabel('Color input').fill('#ff0000');
+  await expect(page.getByLabel('RGB(A)')).toHaveValue('rgb(255, 0, 0)');
+  await page.getByLabel('RGB(A)').fill('rgb(0, 0, 255)');
+  await expect(page.getByLabel('HEX')).toHaveValue('#0000ff');
+  await page.getByLabel('HSL(A)').fill('hsl(120, 100%, 50%)');
+  await expect(page.getByLabel('HEX')).toHaveValue('#00ff00');
+  await page.getByLabel('CMYK').fill('cmyk(0%, 0%, 0%, 0%)');
+  await expect(page.getByLabel('HEX')).toHaveValue('#ffffff');
+});

--- a/lib/color-conversion.ts
+++ b/lib/color-conversion.ts
@@ -1,31 +1,35 @@
-export interface RGB { r: number; g: number; b: number; }
-export interface HSL { h: number; s: number; l: number; }
+export interface RGB { r: number; g: number; b: number }
+export interface RGBA extends RGB { a: number }
+export interface HSL { h: number; s: number; l: number }
+export interface HSLA extends HSL { a: number }
+export interface CMYK { c: number; m: number; y: number; k: number }
 
-export function hexToRgb(hex: string): RGB | null {
-  const cleaned = hex.trim().replace(/^#/, '');
-  if (!/^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(cleaned)) return null;
-  const full = cleaned.length === 3
-    ? cleaned.split('').map((c) => c + c).join('')
-    : cleaned;
-  const num = parseInt(full, 16);
-  return {
-    r: (num >> 16) & 255,
-    g: (num >> 8) & 255,
-    b: num & 255,
-  };
+export function hexToRgba(hex: string): RGBA | null {
+  const cleaned = hex.trim().replace(/^#/, '')
+  if (!/^([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(cleaned)) return null
+  const expanded = cleaned.length <= 4
+    ? cleaned.split('').map(c => c + c).join('')
+    : cleaned
+  const r = parseInt(expanded.slice(0, 2), 16)
+  const g = parseInt(expanded.slice(2, 4), 16)
+  const b = parseInt(expanded.slice(4, 6), 16)
+  const a = expanded.length === 8 ? parseInt(expanded.slice(6, 8), 16) / 255 : 1
+  return { r, g, b, a }
 }
 
-export function rgbToHex({ r, g, b }: RGB): string {
-  return (
-    '#' +
-    [r, g, b]
-      .map((n) => {
-        const clamped = Math.max(0, Math.min(255, Math.round(n)));
-        return clamped.toString(16).padStart(2, '0');
-      })
-      .join('')
-  );
+export const hexToRgb = hexToRgba
+
+export function rgbaToHex({ r, g, b, a }: RGBA): string {
+  const hex = [r, g, b]
+    .map((n) => Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, '0'))
+    .join('');
+  const alpha = Math.round(Math.max(0, Math.min(1, a)) * 255)
+    .toString(16)
+    .padStart(2, '0');
+  return a < 1 ? `#${hex}${alpha}` : `#${hex}`;
 }
+
+export const rgbToHex = (rgb: RGB): string => rgbaToHex({ ...rgb, a: 1 });
 
 export function rgbToHsl({ r, g, b }: RGB): HSL {
   const rNorm = r / 255;
@@ -79,24 +83,30 @@ export function hslToRgb({ h, s, l }: HSL): RGB {
   return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
 }
 
-export function parseRgbString(str: string): RGB | null {
-  const match = str.trim().match(/^rgb\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i);
+export function parseRgbString(str: string): RGBA | null {
+  const match = str
+    .trim()
+    .match(/^rgba?\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(\d*\.?\d+)\s*)?\)$/i);
   if (!match) return null;
   const r = Number(match[1]);
   const g = Number(match[2]);
   const b = Number(match[3]);
-  if ([r, g, b].some((n) => n < 0 || n > 255)) return null;
-  return { r, g, b };
+  const a = match[4] === undefined ? 1 : Number(match[4]);
+  if ([r, g, b].some((n) => n < 0 || n > 255) || a < 0 || a > 1) return null;
+  return { r, g, b, a };
 }
 
-export function parseHslString(str: string): HSL | null {
-  const match = str.trim().match(/^hsl\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/i);
+export function parseHslString(str: string): HSLA | null {
+  const match = str
+    .trim()
+    .match(/^hsla?\s*\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%(?:\s*,\s*(\d*\.?\d+)\s*)?\)$/i);
   if (!match) return null;
   const h = Number(match[1]);
   const s = Number(match[2]);
   const l = Number(match[3]);
-  if ([s, l].some((n) => n < 0 || n > 100)) return null;
-  return { h, s, l };
+  const a = match[4] === undefined ? 1 : Number(match[4]);
+  if ([s, l].some((n) => n < 0 || n > 100) || a < 0 || a > 1) return null;
+  return { h, s, l, a };
 }
 
 export function formatRgb({ r, g, b }: RGB): string {
@@ -107,20 +117,108 @@ export function formatHsl({ h, s, l }: HSL): string {
   return `hsl(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%)`;
 }
 
-export function convertColor(input: string): { hex: string; rgb: string; hsl: string } | null {
-  let rgb: RGB | null = null;
-  if (input.trim().startsWith('#')) {
-    rgb = hexToRgb(input);
-  } else if (input.toLowerCase().startsWith('rgb')) {
-    rgb = parseRgbString(input);
-  } else if (input.toLowerCase().startsWith('hsl')) {
-    const hsl = parseHslString(input);
-    if (hsl) {
-      rgb = hslToRgb(hsl);
-    }
+export function formatRgba({ r, g, b, a }: RGBA): string {
+  return a < 1
+    ? `rgba(${r}, ${g}, ${b}, ${Number(a.toFixed(2))})`
+    : `rgb(${r}, ${g}, ${b})`;
+}
+
+export function formatHsla({ h, s, l, a }: HSLA): string {
+  const base = `hsl(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%)`;
+  return a < 1 ? `hsla(${Math.round(h)}, ${Math.round(s)}%, ${Math.round(l)}%, ${Number(a.toFixed(2))})` : base;
+}
+
+export function formatCmyk({ c, m, y, k }: CMYK): string {
+  return `cmyk(${Math.round(c)}%, ${Math.round(m)}%, ${Math.round(y)}%, ${Math.round(k)}%)`;
+}
+
+export function rgbaToHsla({ r, g, b, a }: RGBA): HSLA {
+  const { h, s, l } = rgbToHsl({ r, g, b });
+  return { h, s, l, a };
+}
+
+export function hslaToRgba({ h, s, l, a }: HSLA): RGBA {
+  const rgb = hslToRgb({ h, s, l });
+  return { ...rgb, a };
+}
+
+export function rgbaToCmyk({ r, g, b }: RGBA): CMYK {
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+  const k = 1 - Math.max(rNorm, gNorm, bNorm);
+  if (k === 1) {
+    return { c: 0, m: 0, y: 0, k: 100 };
   }
-  if (!rgb) return null;
-  const hex = rgbToHex(rgb);
-  const hsl = rgbToHsl(rgb);
-  return { hex, rgb: formatRgb(rgb), hsl: formatHsl(hsl) };
+  const c = ((1 - rNorm - k) / (1 - k)) * 100;
+  const m = ((1 - gNorm - k) / (1 - k)) * 100;
+  const y = ((1 - bNorm - k) / (1 - k)) * 100;
+  return { c, m, y, k: k * 100 };
+}
+
+export function cmykToRgba({ c, m, y, k }: CMYK): RGBA {
+  const cNorm = c / 100;
+  const mNorm = m / 100;
+  const yNorm = y / 100;
+  const kNorm = k / 100;
+  const r = 255 * (1 - cNorm) * (1 - kNorm);
+  const g = 255 * (1 - mNorm) * (1 - kNorm);
+  const b = 255 * (1 - yNorm) * (1 - kNorm);
+  return { r: Math.round(r), g: Math.round(g), b: Math.round(b), a: 1 };
+}
+
+export function parseCmykString(str: string): CMYK | null {
+  const match = str
+    .trim()
+    .match(/^cmyk\s*\(\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/i);
+  if (!match) return null;
+  const c = Number(match[1]);
+  const m = Number(match[2]);
+  const y = Number(match[3]);
+  const k = Number(match[4]);
+  if ([c, m, y, k].some((n) => n < 0 || n > 100)) return null;
+  return { c, m, y, k };
+}
+
+export function parseColor(input: string): RGBA | null {
+  const trimmed = input.trim();
+  if (trimmed.startsWith('#')) return hexToRgba(trimmed);
+  if (/^rgba?/i.test(trimmed)) return parseRgbString(trimmed);
+  if (/^hsla?/i.test(trimmed)) {
+    const hsl = parseHslString(trimmed);
+    return hsl ? hslaToRgba(hsl) : null;
+  }
+  if (/^cmyk/i.test(trimmed)) {
+    const cmyk = parseCmykString(trimmed);
+    return cmyk ? cmykToRgba(cmyk) : null;
+  }
+  return null;
+}
+
+export function convertColor(
+  input: string,
+): { hex: string; rgb: string; hsl: string; cmyk: string } | null {
+  let rgba: RGBA | null = null;
+  const trimmed = input.trim();
+  if (trimmed.startsWith('#')) {
+    rgba = hexToRgba(trimmed);
+  } else if (trimmed.toLowerCase().startsWith('rgb')) {
+    rgba = parseRgbString(trimmed);
+  } else if (trimmed.toLowerCase().startsWith('hsl')) {
+    const hsl = parseHslString(trimmed);
+    if (hsl) rgba = hslaToRgba(hsl);
+  } else if (trimmed.toLowerCase().startsWith('cmyk')) {
+    const cmyk = parseCmykString(trimmed);
+    if (cmyk) rgba = cmykToRgba(cmyk);
+  }
+  if (!rgba) return null;
+  const hex = rgbaToHex(rgba);
+  const hsl = rgbaToHsla(rgba);
+  const cmyk = rgbaToCmyk(rgba);
+  return {
+    hex,
+    rgb: formatRgba(rgba),
+    hsl: formatHsla(hsl),
+    cmyk: formatCmyk(cmyk),
+  };
 }


### PR DESCRIPTION
## Summary
- handle HEX, RGB(A), HSL(A) and CMYK in color converter
- sync all representations bidirectionally
- add hover swatch with color variants
- extend metadata to mention new formats
- support new conversion utilities
- add unit, integration and e2e tests

## Testing
- `npm test`
- `npm run test:e2e` *(fails: about page, color converter, home page and json formatter specs)*

------
https://chatgpt.com/codex/tasks/task_e_68729a11e1f48325bcbc4ac88648d688