### PR TITLE
Enhance Color Contrast Checker

### DIFF
--- a/__tests__/color-contrast-checker-client.test.tsx
+++ b/__tests__/color-contrast-checker-client.test.tsx
@@ -1,0 +1,21 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ColorContrastCheckerClient from "../app/tools/color-contrast-checker/color-contrast-checker-client";
+
+describe("ColorContrastCheckerClient", () => {
+  test("updates ratio and sample on input", async () => {
+    const user = userEvent.setup();
+    render(<ColorContrastCheckerClient />);
+    const fgInput = screen.getByLabelText("Text color value");
+    const bgInput = screen.getByLabelText("Background color value");
+    await user.clear(fgInput);
+    await user.type(fgInput, "#777777");
+    await user.clear(bgInput);
+    await user.type(bgInput, "#ffffff");
+    const ratio = await screen.findByText(/Contrast Ratio/i);
+    expect(ratio.textContent).toContain("4");
+    const sample = screen.getByLabelText("Sample text panel");
+    expect(sample).toHaveStyle({ backgroundColor: "rgb(255, 255, 255)" });
+  });
+});

--- a/__tests__/contrast-ratio.test.ts
+++ b/__tests__/contrast-ratio.test.ts
@@ -1,0 +1,21 @@
+import { calculateContrast } from "../lib/contrast-ratio";
+
+describe("calculateContrast", () => {
+  test("black on white returns 21", () => {
+    const res = calculateContrast("#000", "#fff");
+    expect(res.ratio).toBeCloseTo(21, 2);
+  });
+
+  test("handles named colors and rgb", () => {
+    const res = calculateContrast("red", "rgb(255,255,255)");
+    expect(res.ratio).toBeCloseTo(4, 1);
+  });
+
+  test("resolves css variables", () => {
+    const res = calculateContrast("var(--fg)", "var(--bg)", {
+      "--fg": "#000000",
+      "--bg": "#ffffff",
+    });
+    expect(res.ratio).toBeCloseTo(21, 2);
+  });
+});

--- a/app/tools/color-contrast-checker/color-contrast-checker-client.tsx
+++ b/app/tools/color-contrast-checker/color-contrast-checker-client.tsx
@@ -1,66 +1,46 @@
 // app/tools/color-contrast-checker/color-contrast-checker-client.tsx
-
 "use client";
 
 import { useState, useMemo, ChangeEvent } from "react";
-
-function hexToRgb(hex: string): [number, number, number] {
-  let cleaned = hex.replace(/^#/, "");
-  if (cleaned.length === 3) {
-    cleaned = cleaned
-      .split("")
-      .map((c) => c + c)
-      .join("");
-  }
-  const bigint = parseInt(cleaned, 16);
-  const r = (bigint >> 16) & 255;
-  const g = (bigint >> 8) & 255;
-  const b = bigint & 255;
-  return [r, g, b];
-}
-
-function luminance([r, g, b]: [number, number, number]): number {
-  const [R, G, B] = [r, g, b].map((c) => {
-    const v = c / 255;
-    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
-  });
-  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
-}
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import { calculateContrast } from "@/lib/contrast-ratio";
 
 export default function ColorContrastCheckerClient() {
-  const [fg, setFg] = useState("#000000");
-  const [bg, setBg] = useState("#ffffff");
+  const [fgInput, setFgInput] = useState("#000000");
+  const [bgInput, setBgInput] = useState("#ffffff");
 
-  const contrastRatio = useMemo(() => {
-    const L1 = luminance(hexToRgb(fg));
-    const L2 = luminance(hexToRgb(bg));
-    const [lighter, darker] = L1 > L2 ? [L1, L2] : [L2, L1];
-    return parseFloat(((lighter + 0.05) / (darker + 0.05)).toFixed(2));
-  }, [fg, bg]);
+  const { ratio, fgHex, bgHex } = useMemo(
+    () => calculateContrast(fgInput, bgInput),
+    [fgInput, bgInput],
+  );
 
   const passes = useMemo(() => {
     return {
-      aaNormal: contrastRatio >= 4.5,
-      aaLarge: contrastRatio >= 3,
-      aaaNormal: contrastRatio >= 7,
-      aaaLarge: contrastRatio >= 4.5,
+      aaNormal: ratio >= 4.5,
+      aaLarge: ratio >= 3,
+      aaaNormal: ratio >= 7,
+      aaaLarge: ratio >= 4.5,
     };
-  }, [contrastRatio]);
+  }, [ratio]);
+
+  const handlePicker =
+    (setter: (v: string) => void) => (e: ChangeEvent<HTMLInputElement>) =>
+      setter(e.target.value);
+
+  const handleInput =
+    (setter: (v: string) => void) => (e: ChangeEvent<HTMLInputElement>) =>
+      setter(e.target.value);
 
   const copyCss = async () => {
-    const css = `color: ${fg}; background-color: ${bg};`;
+    const comment = `/* Contrast ratio ${ratio}: AA ${passes.aaNormal ? "PASS" : "FAIL"}, AAA ${passes.aaaNormal ? "PASS" : "FAIL"} */`;
+    const css = `color: ${fgHex};\nbackground-color: ${bgHex};\n${comment}`;
     try {
       await navigator.clipboard.writeText(css);
       alert("✅ CSS copied to clipboard!");
     } catch {
       alert("❌ Failed to copy CSS.");
     }
-  };
-
-  const handleColorChange = (
-    setter: (v: string) => void
-  ) => (e: ChangeEvent<HTMLInputElement>) => {
-    setter(e.target.value);
   };
 
   return (
@@ -76,104 +56,120 @@ export default function ColorContrastCheckerClient() {
         Color Contrast Checker
       </h1>
       <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
-        Verify WCAG compliance by checking contrast ratio between foreground
-        and background colors. 100% client-side, no signup required.
+        Verify WCAG compliance by checking contrast ratio between foreground and
+        background colors. 100% client-side, no signup required.
       </p>
-
-      {/* Color Pickers */}
-      <div className="flex flex-col sm:flex-row sm:justify-center sm:space-x-8 space-y-4 sm:space-y-0 mb-10">
-        <label className="flex items-center space-x-2">
-          <span className="text-sm font-medium text-gray-700">Text Color:</span>
-          <input
-            type="color"
-            value={fg}
-            onChange={handleColorChange(setFg)}
-            className="w-10 h-10 p-0 border-0 bg-transparent cursor-pointer"
-            aria-label="Choose text color"
-          />
-          <span className="font-mono text-sm">{fg}</span>
-        </label>
-        <label className="flex items-center space-x-2">
-          <span className="text-sm font-medium text-gray-700">
-            Background:
-          </span>
-          <input
-            type="color"
-            value={bg}
-            onChange={handleColorChange(setBg)}
-            className="w-10 h-10 p-0 border-0 bg-transparent cursor-pointer"
-            aria-label="Choose background color"
-          />
-          <span className="font-mono text-sm">{bg}</span>
-        </label>
+      <div className="flex flex-col sm:flex-row sm:justify-center sm:space-x-8 space-y-6 sm:space-y-0 mb-10">
+        <div className="space-y-2 text-center sm:text-left">
+          <label
+            htmlFor="fg-input"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Text Color
+          </label>
+          <div className="flex items-center justify-center sm:justify-start space-x-2">
+            <Input
+              id="fg-picker"
+              type="color"
+              value={fgHex}
+              onChange={handlePicker(setFgInput)}
+              aria-label="Choose text color"
+              className="h-10 w-10 p-0 border-0 bg-transparent cursor-pointer"
+            />
+            <Input
+              id="fg-input"
+              aria-label="Text color value"
+              value={fgInput}
+              onChange={handleInput(setFgInput)}
+              className="font-mono w-32"
+            />
+          </div>
+        </div>
+        <div className="space-y-2 text-center sm:text-left">
+          <label
+            htmlFor="bg-input"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Background Color
+          </label>
+          <div className="flex items-center justify-center sm:justify-start space-x-2">
+            <Input
+              id="bg-picker"
+              type="color"
+              value={bgHex}
+              onChange={handlePicker(setBgInput)}
+              aria-label="Choose background color"
+              className="h-10 w-10 p-0 border-0 bg-transparent cursor-pointer"
+            />
+            <Input
+              id="bg-input"
+              aria-label="Background color value"
+              value={bgInput}
+              onChange={handleInput(setBgInput)}
+              className="font-mono w-32"
+            />
+          </div>
+        </div>
       </div>
-
-      {/* Preview */}
       <div
-        className="p-8 rounded-lg border border-gray-200 text-center mb-10"
-        style={{ color: fg, backgroundColor: bg }}
+        aria-label="Sample text panel"
+        className="p-8 rounded-lg border border-gray-200 text-center mb-10 space-y-2"
+        style={{ color: fgHex, backgroundColor: bgHex }}
       >
-        <p className="text-lg font-medium">The quick brown fox jumps over the lazy dog</p>
-      </div>
-
-      {/* Results */}
-      <div className="max-w-md mx-auto space-y-4 mb-10">
-        <p className="text-center text-xl font-semibold">
-          Contrast Ratio:{" "}
-          <span className="text-indigo-600">{contrastRatio}:1</span>
+        <p className="text-base">The quick brown fox jumps over the lazy dog</p>
+        <p className="text-xl font-semibold">
+          The quick brown fox jumps over the lazy dog
         </p>
-        <ul className="space-y-1 text-gray-700">
-          <li>
-            WCAG AA (Normal text):{" "}
-            <span
-              className={
-                passes.aaNormal ? "text-green-600" : "text-red-600"
-              }
-            >
-              {passes.aaNormal ? "Pass" : "Fail"}
-            </span>
-          </li>
-          <li>
-            WCAG AA (Large text ≥18pt):{" "}
-            <span
-              className={
-                passes.aaLarge ? "text-green-600" : "text-red-600"
-              }
-            >
-              {passes.aaLarge ? "Pass" : "Fail"}
-            </span>
-          </li>
-          <li>
-            WCAG AAA (Normal text):{" "}
-            <span
-              className={
-                passes.aaaNormal ? "text-green-600" : "text-red-600"
-              }
-            >
-              {passes.aaaNormal ? "Pass" : "Fail"}
-            </span>
-          </li>
-          <li>
-            WCAG AAA (Large text):{" "}
-            <span
-              className={
-                passes.aaaLarge ? "text-green-600" : "text-red-600"
-              }
-            >
-              {passes.aaaLarge ? "Pass" : "Fail"}
-            </span>
-          </li>
-        </ul>
+        <p className="text-3xl font-bold">
+          The quick brown fox jumps over the lazy dog
+        </p>
       </div>
-
-      {/* Copy CSS */}
+      <div className="max-w-md mx-auto space-y-4 mb-10 text-center">
+        <p className="text-xl font-semibold">
+          Contrast Ratio:{" "}
+          <span className="text-indigo-600">
+            {isNaN(ratio) ? "--" : `${ratio}:1`}
+          </span>
+        </p>
+        {!isNaN(ratio) && (
+          <ul className="space-y-1 text-gray-700" aria-live="polite">
+            <li>
+              WCAG AA Normal:{" "}
+              <span
+                className={`px-2 py-0.5 rounded text-white ${passes.aaNormal ? "bg-green-600" : "bg-red-600"}`}
+              >
+                {passes.aaNormal ? "Pass" : "Fail"}
+              </span>
+            </li>
+            <li>
+              WCAG AA Large:{" "}
+              <span
+                className={`px-2 py-0.5 rounded text-white ${passes.aaLarge ? "bg-green-600" : "bg-red-600"}`}
+              >
+                {passes.aaLarge ? "Pass" : "Fail"}
+              </span>
+            </li>
+            <li>
+              WCAG AAA Normal:{" "}
+              <span
+                className={`px-2 py-0.5 rounded text-white ${passes.aaaNormal ? "bg-green-600" : "bg-red-600"}`}
+              >
+                {passes.aaaNormal ? "Pass" : "Fail"}
+              </span>
+            </li>
+            <li>
+              WCAG AAA Large:{" "}
+              <span
+                className={`px-2 py-0.5 rounded text-white ${passes.aaaLarge ? "bg-green-600" : "bg-red-600"}`}
+              >
+                {passes.aaaLarge ? "Pass" : "Fail"}
+              </span>
+            </li>
+          </ul>
+        )}
+      </div>
       <div className="text-center">
-        <button
-          onClick={copyCss}
-          className="px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition text-sm font-medium"
-        >
-          Copy CSS Snippet
-        </button>
+        <Button onClick={copyCss}>Copy CSS</Button>
       </div>
     </section>
   );

--- a/e2e/color-contrast-checker.spec.ts
+++ b/e2e/color-contrast-checker.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+test("contrast checker fail then pass", async ({ page }) => {
+  await page.goto("/tools/color-contrast-checker");
+  await page.getByLabel("Text color value").fill("#777777");
+  await page.getByLabel("Background color value").fill("#ffffff");
+  await expect(page.getByText("WCAG AA Normal")).toContainText("Fail");
+  await page.getByLabel("Text color value").fill("#000000");
+  await expect(page.getByText("WCAG AA Normal")).toContainText("Pass");
+});

--- a/lib/contrast-ratio.ts
+++ b/lib/contrast-ratio.ts
@@ -1,0 +1,83 @@
+import colorName from "color-name";
+import {
+  hexToRgb,
+  parseRgbString,
+  parseHslString,
+  hslToRgb,
+  rgbToHex,
+} from "./color-conversion";
+
+export type RGBTuple = [number, number, number];
+
+function parseColor(
+  input: string,
+  vars: Record<string, string> = {},
+): RGBTuple | null {
+  let value = input.trim();
+  const varMatch = value.match(/^var\((--[^)]+)\)$/);
+  if (varMatch) {
+    const name = varMatch[1];
+    if (vars[name]) {
+      value = vars[name].trim();
+    } else if (typeof window !== "undefined") {
+      const val = getComputedStyle(document.documentElement).getPropertyValue(
+        name,
+      );
+      if (val) value = val.trim();
+    }
+  }
+  const lower = value.toLowerCase();
+  if (lower in colorName) {
+    const [r, g, b] = (colorName as Record<string, RGBTuple>)[lower];
+    return [r, g, b];
+  }
+  if (value.startsWith("#")) {
+    const rgb = hexToRgb(value);
+    return rgb ? [rgb.r, rgb.g, rgb.b] : null;
+  }
+  if (lower.startsWith("rgb")) {
+    const rgb = parseRgbString(value);
+    return rgb ? [rgb.r, rgb.g, rgb.b] : null;
+  }
+  if (lower.startsWith("hsl")) {
+    const hsl = parseHslString(value);
+    if (hsl) {
+      const rgb = hslToRgb(hsl);
+      return [rgb.r, rgb.g, rgb.b];
+    }
+  }
+  return null;
+}
+
+function luminance([r, g, b]: RGBTuple): number {
+  const [R, G, B] = [r, g, b].map((c) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+export function calculateContrast(
+  fg: string,
+  bg: string,
+  vars: Record<string, string> = {},
+): { ratio: number; fgHex: string; bgHex: string } {
+  const fgRgb = parseColor(fg, vars);
+  const bgRgb = parseColor(bg, vars);
+  if (!fgRgb || !bgRgb) {
+    return { ratio: NaN, fgHex: "#000000", bgHex: "#ffffff" };
+  }
+  const ratioVal = (() => {
+    const L1 = luminance(fgRgb);
+    const L2 = luminance(bgRgb);
+    const [lighter, darker] = L1 > L2 ? [L1, L2] : [L2, L1];
+    return parseFloat(((lighter + 0.05) / (darker + 0.05)).toFixed(2));
+  })();
+  return {
+    ratio: ratioVal,
+    fgHex: rgbToHex({ r: fgRgb[0], g: fgRgb[1], b: fgRgb[2] }),
+    bgHex: rgbToHex({ r: bgRgb[0], g: bgRgb[1], b: bgRgb[2] }),
+  };
+}
+
+export { parseColor };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "bcryptjs": "^3.0.2",
+        "color-name": "^1.1.4",
         "diff": "^8.0.2",
         "docx": "^9.5.1",
         "dompurify": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",
+    "color-name": "^1.1.4",
     "diff": "^8.0.2",
     "docx": "^9.5.1",
     "dompurify": "^3.2.6",

--- a/types/color-name.d.ts
+++ b/types/color-name.d.ts
@@ -1,0 +1,4 @@
+declare module 'color-name' {
+  const colors: Record<string, [number, number, number]>;
+  export default colors;
+}


### PR DESCRIPTION
## Summary
- allow diverse color formats in new `calculateContrast` util
- update Color Contrast Checker UI with text fields and badges
- export CSS snippet with contrast compliance comment
- add unit and integration tests for contrast logic
- add e2e test for failing then passing combo
- include `color-name` types

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run test:e2e` *(fails: 45 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68729a0b8ff483258a11b964da705101