### PR TITLE
Add drag-and-drop image compressor with tests

### DIFF
--- a/__tests__/image-compressor-client.test.tsx
+++ b/__tests__/image-compressor-client.test.tsx
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ImageCompressorClient from '../app/tools/image-compressor/image-compressor-client';
+
+describe('ImageCompressorClient file handling', () => {
+  function createFile() {
+    return new File([new Uint8Array([137,80,78,71,13,10,26,10])], 'test.png', {
+      type: 'image/png',
+    });
+  }
+
+  test('handles multiple file uploads', async () => {
+    const user = userEvent.setup();
+    render(<ImageCompressorClient />);
+    const dropzone = screen.getByRole('button', { name: /upload images/i });
+    const input = dropzone.querySelector('input') as HTMLInputElement;
+    const files = [createFile(), createFile()];
+    await user.upload(input, files);
+    expect(await screen.findAllByAltText('Original')).toHaveLength(2);
+  });
+
+  test('drop event adds files', async () => {
+    render(<ImageCompressorClient />);
+    const dropzone = screen.getByRole('button', { name: /upload images/i });
+    const file = createFile();
+    const data = new DataTransfer();
+    data.items.add(file);
+    fireEvent.drop(dropzone, { dataTransfer: data });
+    expect(await screen.findByAltText('Original')).toBeInTheDocument();
+  });
+});

--- a/app/tools/image-compressor/compress-utils.test.ts
+++ b/app/tools/image-compressor/compress-utils.test.ts
@@ -1,4 +1,4 @@
-import { compressBuffer, loadFile } from './compress-utils';
+import { compressBuffer, compressBufferStream, loadFile } from './compress-utils';
 
 const samplePath = 'public/favicon.png';
 
@@ -8,4 +8,13 @@ test('compressBuffer reduces size', async () => {
   const orig = await loadFile(samplePath);
   const compressed = await compressBuffer(orig, 0.5);
   expect(compressed.length).toBeLessThan(orig.length);
+});
+
+// stream compression emits chunks
+test('compressBufferStream emits chunks', async () => {
+  const orig = await loadFile(samplePath);
+  const chunks: Buffer[] = [];
+  const buf = await compressBufferStream(orig, 0.5, (c) => chunks.push(c));
+  expect(chunks.length).toBeGreaterThan(0);
+  expect(buf.length).toBeLessThan(orig.length);
 });

--- a/app/tools/image-compressor/compress-utils.ts
+++ b/app/tools/image-compressor/compress-utils.ts
@@ -1,14 +1,34 @@
 import sharp from 'sharp';
 import fs from 'fs/promises';
+import { Readable } from 'stream';
 
-// Used only in tests: compresses an image buffer using sharp and returns the
-// compressed buffer.
+// compresses an image buffer using sharp
 export async function compressBuffer(buffer: Buffer, quality: number): Promise<Buffer> {
   const q = Math.min(Math.max(quality, 0), 1);
   return sharp(buffer).jpeg({ quality: Math.round(q * 100) }).toBuffer();
 }
 
-// Helper to load a file for tests.
+// stream-based compression that reports chunks via callback
+export async function compressBufferStream(
+  buffer: Buffer,
+  quality: number,
+  onChunk?: (chunk: Buffer) => void
+): Promise<Buffer> {
+  const readable = Readable.from(buffer);
+  const transform = sharp().jpeg({ quality: Math.round(Math.min(Math.max(quality, 0), 1) * 100) });
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    readable.pipe(transform);
+    transform.on('data', (c: Buffer) => {
+      chunks.push(c);
+      if (onChunk) onChunk(c);
+    });
+    transform.on('error', reject);
+    transform.on('end', () => resolve(Buffer.concat(chunks)));
+  });
+}
+
+// Helper to load a file for tests
 export async function loadFile(path: string): Promise<Buffer> {
   return fs.readFile(path);
 }

--- a/app/tools/image-compressor/image-compressor-client.tsx
+++ b/app/tools/image-compressor/image-compressor-client.tsx
@@ -2,118 +2,124 @@
 
 "use client";
 
-import { useState, useEffect, ChangeEvent } from "react";
-import PreviewImage from "@/components/PreviewImage";
+import { useState, useEffect, useRef } from "react";
+import BeforeAfter from "@/components/BeforeAfter";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
 
+interface Item {
+  file: File;
+  originalUrl: string;
+  compressedUrl: string | null;
+  originalSize: number;
+  compressedSize: number | null;
+  width: number;
+  height: number;
+}
+
 export default function ImageCompressorClient() {
-  const [file, setFile] = useState<File | null>(null);
-  const [originalUrl, setOriginalUrl] = useState<string | null>(null);
-  const [originalSize, setOriginalSize] = useState<number | null>(null);
-  const [dimensions, setDimensions] = useState<{ w: number; h: number } | null>(
-    null
-  );
-
+  const [items, setItems] = useState<Item[]>([]);
   const [quality, setQuality] = useState(0.8);
-  const [compressedUrl, setCompressedUrl] = useState<string | null>(null);
-  const [compressedSize, setCompressedSize] = useState<number | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [processing, setProcessing] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
+  const processingRef = useRef(false);
 
-  // reset preview when file changes
-  useEffect(() => {
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result as string;
-      const img = new window.Image();
-      img.onload = () => {
-        setOriginalUrl(result);
-        setOriginalSize(file.size);
-        setDimensions({ w: img.naturalWidth, h: img.naturalHeight });
-        setError(null);
-      };
-      img.src = result;
-    };
-    reader.readAsDataURL(file);
-  }, [file]);
-
+  // cleanup urls
   useEffect(() => {
     return () => {
-      if (compressedUrl) URL.revokeObjectURL(compressedUrl);
+      items.forEach((it) => {
+        URL.revokeObjectURL(it.originalUrl);
+        if (it.compressedUrl) URL.revokeObjectURL(it.compressedUrl);
+      });
     };
-  }, [compressedUrl]);
+  }, [items]);
 
-  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (compressedUrl) URL.revokeObjectURL(compressedUrl);
-    if (originalUrl && originalUrl.startsWith("blob:")) {
-      URL.revokeObjectURL(originalUrl);
-    }
-    setCompressedUrl(null);
-    setCompressedSize(null);
-    setFile(e.target.files?.[0] ?? null);
-  };
-
-  const compressImage = () => {
-    if (!file || !originalUrl) return;
-    setProcessing(true);
-    setError(null);
-
-    // Load the image from the selected file
-    const img = new window.Image();
-    img.src = originalUrl;
-
-    img.onload = () => {
-      try {
-        const canvas = document.createElement("canvas");
-        canvas.width = img.naturalWidth;
-        canvas.height = img.naturalHeight;
-        const ctx = canvas.getContext("2d");
-        if (!ctx) throw new Error('Canvas not supported');
-        ctx.drawImage(img, 0, 0);
-
-        if (!canvas.toBlob) {
-          throw new Error('Browser does not support image compression');
-        }
-
-        canvas.toBlob(
-          (blob) => {
-            if (blob) {
-              // Revoke any previous compressed preview to avoid memory leaks
-              if (compressedUrl) {
-                URL.revokeObjectURL(compressedUrl);
-              }
-              const url = URL.createObjectURL(blob);
-              setCompressedUrl(url);
-              setCompressedSize(blob.size);
-            } else {
-              setError("Compression failed.");
-            }
-            setProcessing(false);
+  const handleFiles = (files: FileList | null) => {
+    if (!files) return;
+    const list = Array.from(files).filter((f) => f.type.startsWith("image/"));
+    list.forEach((file) => {
+      const url = URL.createObjectURL(file);
+      const img = new Image();
+      img.onload = () => {
+        setItems((prev) => [
+          ...prev,
+          {
+            file,
+            originalUrl: url,
+            compressedUrl: null,
+            originalSize: file.size,
+            compressedSize: null,
+            width: img.naturalWidth,
+            height: img.naturalHeight,
           },
-          file.type || "image/jpeg",
-          quality
-        );
-      } catch {
-        setError("An error occurred during compression.");
-        setProcessing(false);
-      }
-    };
-
-    img.onerror = () => {
-      setError("Failed to load image for compression.");
-      setProcessing(false);
-    };
+        ]);
+      };
+      img.src = url;
+    });
   };
 
-  const downloadCompressed = () => {
-    if (!compressedUrl) return;
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const runCompression = async () => {
+    if (processingRef.current) return;
+    processingRef.current = true;
+    for (const it of items) {
+      await new Promise((res) => setTimeout(res));
+      await compress(it);
+    }
+    processingRef.current = false;
+  };
+
+  useEffect(() => {
+    if (items.length === 0) return;
+    const t = setTimeout(runCompression, 200);
+    return () => clearTimeout(t);
+  }, [quality, items]);
+
+  const compress = async (item: Item) => {
+    const img = new Image();
+    img.src = item.originalUrl;
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject();
+    });
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(img, 0, 0);
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob(resolve, item.file.type || "image/jpeg", quality)
+    );
+    if (!blob) return;
+    setItems((prev) =>
+      prev.map((it) =>
+        it.originalUrl === item.originalUrl
+          ? {
+              ...it,
+              compressedUrl: it.compressedUrl
+                ? (URL.revokeObjectURL(it.compressedUrl),
+                  URL.createObjectURL(blob))
+                : URL.createObjectURL(blob),
+              compressedSize: blob.size,
+            }
+          : it
+      )
+    );
+  };
+
+  const download = (item: Item) => {
+    if (!item.compressedUrl) return;
     const a = document.createElement("a");
-    a.href = compressedUrl;
-    a.download = `compressed-${file?.name ?? "image"}`;
+    a.href = item.compressedUrl;
+    a.download = `compressed-${item.file.name}`;
     a.click();
   };
+
+  const preset = (q: number) => setQuality(q);
 
   return (
     <section
@@ -128,111 +134,102 @@ export default function ImageCompressorClient() {
         Image Compressor
       </h1>
       <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto leading-relaxed">
-        Upload an image, adjust quality, and download a smaller file. 100%
-        client-side, no signup required.
+        Drag & drop images or browse to compress them directly in your browser.
       </p>
 
-      <div className="max-w-md mx-auto mb-8">
-        <Input
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+        tabIndex={0}
+        role="button"
+        aria-label="Upload images"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            fileInput.current?.click();
+          }
+        }}
+        onClick={() => fileInput.current?.click()}
+        className="mb-8 max-w-xl mx-auto p-8 border-2 border-dashed rounded-lg text-center cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      >
+        <p className="text-gray-700">Drag & drop images here or click to browse.</p>
+        <input
+          ref={fileInput}
           type="file"
           accept="image/*"
-          onChange={handleFileChange}
-          className="file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-indigo-600 file:text-white hover:file:bg-indigo-700 focus-visible:ring-2 focus-visible:ring-indigo-500"
+          multiple
+          onChange={(e) => handleFiles(e.target.files)}
+          className="hidden"
         />
       </div>
 
-      {originalUrl && (
-        <>
-          <div className="max-w-md mx-auto mb-8">
-            <label
-              htmlFor="quality"
-              className="block mb-2 font-medium text-gray-800"
-            >
-              Quality:{" "}
-              <span className="font-semibold">
-                {Math.round(quality * 100)}%
-              </span>
-            </label>
-            <Input
-              id="quality"
-              type="range"
-              min={0.1}
-              max={1}
-              step={0.1}
-              value={quality}
-              onChange={(e) => setQuality(Number(e.target.value))}
-              className="w-full"
-            />
-          </div>
-
-          <div className="text-center mb-8">
-            <Button
-              onClick={compressImage}
-              disabled={processing}
-              className={`${processing ? "opacity-60 cursor-not-allowed" : ""}`}
-            >
-              {processing ? "Compressing..." : "Compress Image"}
-            </Button>
-          </div>
-
-          {error && (
-            <div
-              role="alert"
-              className="max-w-md mx-auto mb-8 p-4 bg-red-50 border border-red-200 text-red-700 rounded-md"
-            >
-              {error}
-            </div>
-          )}
-
-          <div className="grid gap-8 md:grid-cols-2 max-w-4xl mx-auto mb-8">
-            <div className="text-center">
-              <p className="font-medium mb-2">Original</p>
-              {dimensions && (
-                <PreviewImage
-                  src={originalUrl}
-                  alt="Original"
-                  width={dimensions.w}
-                  height={dimensions.h}
-                />
-              )}
-              {originalSize != null && (
-                <p className="mt-2 text-sm text-gray-600">
-                  {(originalSize / 1024).toFixed(1)} KB
-                </p>
-              )}
-            </div>
-
-            {compressedUrl && (
-              <div className="text-center">
-                <p className="font-medium mb-2">Compressed</p>
-                {dimensions && (
-                  <PreviewImage
-                    src={compressedUrl}
-                    alt="Compressed"
-                    width={dimensions.w}
-                    height={dimensions.h}
-                  />
-                )}
-                {compressedSize != null && (
-                  <p className="mt-2 text-sm text-gray-600">
-                    {(compressedSize / 1024).toFixed(1)} KB
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
-
-          {compressedUrl && (
-            <div className="text-center">
-              <Button
-                onClick={downloadCompressed}
-                className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
-              >
-                Download Compressed Image
+      {items.length > 0 && (
+        <div className="max-w-xl mx-auto mb-8 space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-x-2">
+              <Button type="button" onClick={() => preset(0.3)} className="text-sm">
+                Low
+              </Button>
+              <Button type="button" onClick={() => preset(0.6)} className="text-sm">
+                Medium
+              </Button>
+              <Button type="button" onClick={() => preset(0.8)} className="text-sm">
+                High
               </Button>
             </div>
-          )}
-        </>
+            <label htmlFor="quality" className="font-medium text-gray-800">
+              Quality: {Math.round(quality * 100)}%
+            </label>
+          </div>
+          <Input
+            id="quality"
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.01}
+            value={quality}
+            onChange={(e) => setQuality(parseFloat(e.target.value))}
+            aria-label="Custom quality"
+            className="w-full"
+          />
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <ul className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+          {items.map((it, idx) => (
+            <li key={idx} className="list-none space-y-2 text-center">
+              {it.compressedUrl ? (
+                <BeforeAfter
+                  before={it.originalUrl}
+                  after={it.compressedUrl}
+                  width={it.width}
+                  height={it.height}
+                  altBefore="Original"
+                  altAfter="Compressed"
+                />
+              ) : (
+                <img
+                  src={it.originalUrl}
+                  alt="Original"
+                  width={it.width}
+                  height={it.height}
+                  className="w-full h-auto object-contain rounded-lg border border-gray-200 shadow-sm"
+                />
+              )}
+              <p className="text-sm text-gray-600">
+                {it.compressedSize != null
+                  ? `${(it.compressedSize / 1024).toFixed(1)} KB`
+                  : `${((it.originalSize * quality) / 1024).toFixed(1)} KB (est.)`} /{' '}
+                {(it.originalSize / 1024).toFixed(1)} KB
+              </p>
+              {it.compressedUrl && (
+                <Button onClick={() => download(it)} className="w-full text-sm">
+                  Download
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
       )}
     </section>
   );

--- a/components/BeforeAfter.tsx
+++ b/components/BeforeAfter.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+
+export interface BeforeAfterProps {
+  before: string;
+  after: string;
+  width: number;
+  height: number;
+  altBefore?: string;
+  altAfter?: string;
+}
+
+export default function BeforeAfter({
+  before,
+  after,
+  width,
+  height,
+  altBefore = "Before",
+  altAfter = "After",
+}: BeforeAfterProps) {
+  const [pos, setPos] = useState(0.5);
+  return (
+    <div className="relative w-full" style={{ maxWidth: width, height }}>
+      <img
+        src={after}
+        alt={altAfter}
+        width={width}
+        height={height}
+        className="w-full h-full object-contain rounded-lg border border-gray-200 shadow-sm"
+      />
+      <img
+        src={before}
+        alt={altBefore}
+        width={width}
+        height={height}
+        className="absolute top-0 left-0 w-full h-full object-contain rounded-lg pointer-events-none"
+        style={{ clipPath: `inset(0 ${100 - pos * 100}% 0 0)` }}
+      />
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={pos}
+        aria-label="Before after slider"
+        onChange={(e) => setPos(parseFloat(e.target.value))}
+        className="absolute bottom-1 left-0 w-full h-2 opacity-80"
+      />
+    </div>
+  );
+}

--- a/e2e/image-compressor.spec.ts
+++ b/e2e/image-compressor.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('upload compress and download', async ({ page }) => {
+  await page.goto('/tools/image-compressor');
+  const filePath = path.join(__dirname, '../public/favicon.png');
+  await page.getByLabel('Upload images').setInputFiles(filePath);
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  const dlPath = await download.path();
+  expect(dlPath).not.toBeNull();
+});


### PR DESCRIPTION
## Summary
- add BeforeAfter component
- upgrade image compressor client for batch uploads & previews
- support stream-based compression utils
- test client dropzone logic and utils
- test end-to-end compression flow

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68729a04e5208325a516f06cb444c9f6