### PR TITLE
Enhance image compressor

### DIFF
--- a/__tests__/image-compressor-client.test.tsx
+++ b/__tests__/image-compressor-client.test.tsx
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ImageCompressorClient from "../app/tools/image-compressor/image-compressor-client";
+
+describe("ImageCompressorClient", () => {
+  test("drop zone is focusable with aria label", () => {
+    render(<ImageCompressorClient />);
+    const zone = screen.getByRole("button", { name: /upload images/i });
+    expect(zone).toHaveAttribute("tabindex", "0");
+  });
+
+  test("file input accepts multiple files", async () => {
+    const user = userEvent.setup();
+    render(<ImageCompressorClient />);
+    const input = screen.getByLabelText(/image files/i) as HTMLInputElement;
+    const file1 = new File(["a"], "a.png", { type: "image/png" });
+    const file2 = new File(["b"], "b.png", { type: "image/png" });
+    await user.upload(input, [file1, file2]);
+    expect(input.files?.length).toBe(2);
+  });
+});

--- a/app/tools/image-compressor/compress-utils.test.ts
+++ b/app/tools/image-compressor/compress-utils.test.ts
@@ -9,3 +9,10 @@ test('compressBuffer reduces size', async () => {
   const compressed = await compressBuffer(orig, 0.5);
   expect(compressed.length).toBeLessThan(orig.length);
 });
+
+test('lower quality produces smaller output', async () => {
+  const orig = await loadFile(samplePath);
+  const high = await compressBuffer(orig, 0.9);
+  const low = await compressBuffer(orig, 0.3);
+  expect(low.length).toBeLessThan(high.length);
+});

--- a/app/tools/image-compressor/compress-utils.ts
+++ b/app/tools/image-compressor/compress-utils.ts
@@ -1,14 +1,19 @@
 import sharp from 'sharp';
 import fs from 'fs/promises';
 
-// Used only in tests: compresses an image buffer using sharp and returns the
-// compressed buffer.
+/**
+ * Compress an image buffer using sharp.
+ * @param buffer Image data to compress
+ * @param quality Compression quality between 0 and 1
+ */
 export async function compressBuffer(buffer: Buffer, quality: number): Promise<Buffer> {
   const q = Math.min(Math.max(quality, 0), 1);
   return sharp(buffer).jpeg({ quality: Math.round(q * 100) }).toBuffer();
 }
 
-// Helper to load a file for tests.
+/**
+ * Read a file from disk (test helper).
+ */
 export async function loadFile(path: string): Promise<Buffer> {
   return fs.readFile(path);
 }

--- a/components/BeforeAfterSlider.tsx
+++ b/components/BeforeAfterSlider.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useState } from "react";
+import Image from "next/image";
+
+export interface BeforeAfterSliderProps {
+  before: string;
+  after: string;
+  width: number;
+  height: number;
+  alt?: string;
+}
+
+export default function BeforeAfterSlider({
+  before,
+  after,
+  width,
+  height,
+  alt = "image",
+}: BeforeAfterSliderProps) {
+  const [pos, setPos] = useState(50);
+  return (
+    <div className="relative w-full" style={{ maxWidth: width }}>
+      <div
+        className="relative overflow-hidden rounded-lg border border-gray-200 shadow-sm"
+        style={{ paddingTop: `${(height / width) * 100}%` }}
+      >
+        <Image
+          src={before}
+          alt={alt}
+          fill
+          unoptimized
+          className="object-cover"
+        />
+        <Image
+          src={after}
+          alt={alt}
+          fill
+          unoptimized
+          style={{ clipPath: `inset(0 0 0 ${pos}%)` }}
+          className="absolute top-0 left-0 object-cover"
+        />
+      </div>
+      <input
+        aria-label="Compare images"
+        type="range"
+        min={0}
+        max={100}
+        value={pos}
+        onChange={(e) => setPos(Number(e.target.value))}
+        className="w-full mt-2"
+      />
+    </div>
+  );
+}

--- a/e2e/image-compressor.spec.ts
+++ b/e2e/image-compressor.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+
+test("upload compress and download image", async ({ page }) => {
+  await page.goto("/tools/image-compressor");
+  const filePath = path.resolve("public/favicon.png");
+  await page.setInputFiles('input[type="file"]', filePath);
+  await page.getByRole("button", { name: /compress images/i }).click();
+  await expect(page.getByRole("button", { name: "Download" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add before/after slider component
- redesign image compressor client for drag & drop batches
- document compress utils and add lower-quality test
- test accessibility of drop zone and add e2e workflow

## Testing
- `npm test`
- `npm run test:e2e` *(fails: about page responsive layout, hero CTA, mobile navigation, image compressor upload compress download, json formatter, tools text-sorter)*

------
https://chatgpt.com/codex/tasks/task_e_68729a04e5208325a516f06cb444c9f6