### PR TITLE
Enhance image compressor

### DIFF
--- a/__tests__/image-compressor-client.test.tsx
+++ b/__tests__/image-compressor-client.test.tsx
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ImageCompressorClient from '../app/tools/image-compressor/image-compressor-client';
+
+function createFile(name: string) {
+  const data = new Uint8Array([137,80,78,71,13,10,26,10]);
+  return new File([data], name, { type: 'image/png' });
+}
+
+describe('ImageCompressorClient file handling', () => {
+  test('shows previews for multiple files', async () => {
+    const user = userEvent.setup();
+    render(<ImageCompressorClient />);
+    const input = screen.getByLabelText(/drag and drop images/i) as HTMLInputElement;
+    await user.upload(input, [createFile('a.png'), createFile('b.png')]);
+    const previews = await screen.findAllByAltText(/Original image/);
+    expect(previews).toHaveLength(2);
+  });
+});

--- a/app/tools/image-compressor/compress-utils.test.ts
+++ b/app/tools/image-compressor/compress-utils.test.ts
@@ -9,3 +9,11 @@ test('compressBuffer reduces size', async () => {
   const compressed = await compressBuffer(orig, 0.5);
   expect(compressed.length).toBeLessThan(orig.length);
 });
+
+test('compressBuffer clamps quality', async () => {
+  const orig = await loadFile(samplePath);
+  const compressedHigh = await compressBuffer(orig, 2);
+  const compressedLow = await compressBuffer(orig, -1);
+  expect(compressedHigh.length).toBeLessThan(orig.length);
+  expect(compressedLow.length).toBeLessThan(orig.length);
+});

--- a/app/tools/image-compressor/compress-utils.ts
+++ b/app/tools/image-compressor/compress-utils.ts
@@ -4,7 +4,7 @@ import fs from 'fs/promises';
 // Used only in tests: compresses an image buffer using sharp and returns the
 // compressed buffer.
 export async function compressBuffer(buffer: Buffer, quality: number): Promise<Buffer> {
-  const q = Math.min(Math.max(quality, 0), 1);
+  const q = Math.min(Math.max(quality, 0.01), 1);
   return sharp(buffer).jpeg({ quality: Math.round(q * 100) }).toBuffer();
 }
 

--- a/components/BeforeAfterSlider.tsx
+++ b/components/BeforeAfterSlider.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useState } from "react";
+import PreviewImage from "./PreviewImage";
+
+interface Props {
+  original: string;
+  compressed: string;
+  width: number;
+  height: number;
+  alt: string;
+}
+
+export default function BeforeAfterSlider({
+  original,
+  compressed,
+  width,
+  height,
+  alt,
+}: Props) {
+  const [ratio, setRatio] = useState(0.5);
+  return (
+    <div className="relative w-full">
+      <PreviewImage src={original} alt={alt} width={width} height={height} />
+      <div className="absolute inset-0 overflow-hidden rounded-lg pointer-events-none">
+        <img
+          src={compressed}
+          alt=""
+          className="absolute inset-0 w-full h-full object-contain"
+          style={{ clipPath: `inset(0 0 0 ${ratio * 100}% )` }}
+        />
+      </div>
+      <input
+        aria-label="Before After slider"
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={ratio}
+        onChange={(e) => setRatio(parseFloat(e.target.value))}
+        className="absolute bottom-2 left-0 right-0 w-full pointer-events-auto"
+      />
+    </div>
+  );
+}

--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useRef, useState } from "react";
+
+export default function DropZone({ onFiles }: { onFiles: (files: FileList) => void }) {
+  const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = (files: FileList | null) => {
+    if (files && files.length) {
+      onFiles(files);
+    }
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="Drag and drop images or browse"
+      onClick={() => inputRef.current?.click()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragging(false);
+        handleFiles(e.dataTransfer?.files ?? null);
+      }}
+      className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 ${dragging ? "bg-indigo-50" : "bg-white"}`}
+    >
+      <p className="text-gray-700">
+        Drag & drop images or <span className="text-indigo-600 underline">browse</span>
+      </p>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={(e) => handleFiles(e.target.files)}
+        className="hidden"
+      />
+    </div>
+  );
+}

--- a/e2e/image-compressor.spec.ts
+++ b/e2e/image-compressor.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+const samplePath = 'public/favicon.png';
+
+test('image compressor compresses and shows download button', async ({ page }) => {
+  await page.goto('/tools/image-compressor');
+  await page.setInputFiles('input[type="file"]', samplePath);
+  await page.getByRole('button', { name: 'Compress Images' }).click();
+  await expect(page.getByRole('button', { name: 'Download' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- enable multi-file drag & drop uploads with new DropZone component
- add BeforeAfterSlider for easy original vs. compressed comparison
- extend image-compressor client page with batch processing and quality presets
- clamp quality in compress utils and improve tests
- add integration, unit and e2e tests for image compressor

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: browser errors and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68729a04e5208325a516f06cb444c9f6