### PR TITLE
Refactor image compressor

### DIFF
--- a/__tests__/image-compressor-client.test.tsx
+++ b/__tests__/image-compressor-client.test.tsx
@@ -9,15 +9,13 @@ function createFile(name: string) {
 }
 
 describe("ImageCompressorClient file handling", () => {
-  test("shows previews for multiple files", async () => {
+  test("shows preview after file upload", async () => {
     const user = userEvent.setup();
     render(<ImageCompressorClient />);
-    const input = screen.getByLabelText(
-      /drag and drop images/i,
-    ) as HTMLInputElement;
-    await user.upload(input, [createFile("a.png"), createFile("b.png")]);
-    const previews = await screen.findAllByAltText(/Original image/);
-    expect(previews).toHaveLength(2);
+    const input = screen.getByLabelText(/drag and drop/i) as HTMLInputElement;
+    await user.upload(input, [createFile("a.png")]);
+    const preview = await screen.findByAltText(/Original image/i);
+    expect(preview).toBeInTheDocument();
   });
 
   test("renders compressed preview after compression", async () => {
@@ -46,12 +44,10 @@ describe("ImageCompressorClient file handling", () => {
     });
 
     render(<ImageCompressorClient />);
-    const input = screen.getByLabelText(
-      /drag and drop images/i,
-    ) as HTMLInputElement;
+    const input = screen.getByLabelText(/drag and drop/i) as HTMLInputElement;
     await user.upload(input, [createFile("a.png")]);
-    await user.click(screen.getByRole("button", { name: /compress images/i }));
-    const img = await screen.findByAltText(/compressed image 1/i);
+    await user.click(screen.getByRole("button", { name: /compress/i }));
+    const img = await screen.findByAltText(/compressed image/i);
     expect(img).toHaveAttribute("src", "blob:test");
     urlSpy.mockRestore();
   });

--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -1,7 +1,13 @@
 "use client";
 import { useRef, useState } from "react";
 
-export default function DropZone({ onFiles }: { onFiles: (files: FileList) => void }) {
+export default function DropZone({
+  onFiles,
+  multiple = false,
+}: {
+  onFiles: (files: FileList) => void;
+  multiple?: boolean;
+}) {
   const [dragging, setDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -15,7 +21,7 @@ export default function DropZone({ onFiles }: { onFiles: (files: FileList) => vo
     <div
       role="button"
       tabIndex={0}
-      aria-label="Drag and drop images or browse"
+      aria-label={`Drag and drop ${multiple ? "images" : "image"} or browse`}
       onClick={() => inputRef.current?.click()}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
@@ -33,13 +39,13 @@ export default function DropZone({ onFiles }: { onFiles: (files: FileList) => vo
       className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 ${dragging ? "bg-indigo-50" : "bg-white"}`}
     >
       <p className="text-gray-700">
-        Drag & drop images or <span className="text-indigo-600 underline">browse</span>
+        Drag & drop {multiple ? "images" : "image"} or <span className="text-indigo-600 underline">browse</span>
       </p>
       <input
         ref={inputRef}
         type="file"
         accept="image/*"
-        multiple
+        multiple={multiple}
         onChange={(e) => handleFiles(e.target.files)}
         className="hidden"
       />


### PR DESCRIPTION
## Summary
- update DropZone to support single-file mode
- rebuild Image Compressor to handle a single image with side‑by‑side previews and better controls
- adjust tests for the new compressor behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872bb62e2708325a2eea3af71ae896f