### PR TITLE
Implement improved image compressor UI

### DIFF
--- a/app/tools/image-compressor/image-compressor-client.tsx
+++ b/app/tools/image-compressor/image-compressor-client.tsx
@@ -1,123 +1,120 @@
-// app/tools/image-compressor/image-compressor-client.tsx
-
 "use client";
 
 import { useState, useEffect } from "react";
 import PreviewImage from "@/components/PreviewImage";
-import Button from "@/components/Button";
 import DropZone from "@/components/DropZone";
-
-interface Item {
-  file: File;
-  originalUrl: string;
-  originalSize: number;
-  width: number;
-  height: number;
-  compressedUrl: string | null;
-  compressedSize: number | null;
-}
+import Button from "@/components/Button";
+import Spinner from "@/components/Spinner";
+import useDebounce from "@/lib/useDebounce";
 
 const PRESETS = [
-  { label: "Low", value: 0.4 },
-  { label: "Medium", value: 0.7 },
-  { label: "High", value: 0.9 },
+  { label: "Low (50%)", value: 0.5 },
+  { label: "Medium (75%)", value: 0.75 },
+  { label: "High (90%)", value: 0.9 },
 ];
 
 export default function ImageCompressorClient() {
-  const [items, setItems] = useState<Item[]>([]);
-  const [quality, setQuality] = useState(0.8);
+  const [file, setFile] = useState<File | null>(null);
+  const [originalUrl, setOriginalUrl] = useState<string | null>(null);
+  const [compressedUrl, setCompressedUrl] = useState<string | null>(null);
+  const [originalSize, setOriginalSize] = useState<number>(0);
+  const [compressedSize, setCompressedSize] = useState<number>(0);
+  const [dimensions, setDimensions] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  const [sliderValue, setSliderValue] = useState(75);
+  const debouncedSlider = useDebounce(sliderValue, 200);
+  const [quality, setQuality] = useState(0.75);
+
   const [processing, setProcessing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const handleFiles = (files: FileList) => {
-    const loadPromises = Array.from(files).map(
-      (file) =>
-        new Promise<Item>((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onload = () => {
-            const url = reader.result as string;
-            const img = new window.Image();
-            img.onload = () =>
-              resolve({
-                file,
-                originalUrl: url,
-                originalSize: file.size,
-                width: img.naturalWidth,
-                height: img.naturalHeight,
-                compressedUrl: null,
-                compressedSize: null,
-              });
-            img.onerror = () => reject(new Error("load"));
-            img.src = url;
-          };
-          reader.onerror = () => reject(new Error("read"));
-          reader.readAsDataURL(file);
-        }),
-    );
-
-    Promise.all(loadPromises)
-      .then((list) => {
-        setItems(list);
-        setError(null);
-      })
-      .catch(() => setError("Failed to load image"));
-  };
+  useEffect(() => {
+    setQuality(debouncedSlider / 100);
+  }, [debouncedSlider]);
 
   useEffect(() => {
     return () => {
-      items.forEach((it) => {
-        if (it.compressedUrl) URL.revokeObjectURL(it.compressedUrl);
-        if (it.originalUrl.startsWith("blob:"))
-          URL.revokeObjectURL(it.originalUrl);
-      });
+      if (originalUrl && originalUrl.startsWith("blob:")) URL.revokeObjectURL(originalUrl);
+      if (compressedUrl) URL.revokeObjectURL(compressedUrl);
     };
-  }, [items]);
+  }, [originalUrl, compressedUrl]);
 
-  const compressImages = async (previewOnly = false) => {
-    setProcessing(true);
-    const updated: Item[] = [];
-    for (const item of items) {
-      const img = new window.Image();
-      img.src = item.originalUrl;
-      await new Promise<void>((res, rej) => {
-        img.onload = () => res();
-        img.onerror = () => rej(new Error("load"));
-      });
-      const canvas = document.createElement("canvas");
-      canvas.width = img.naturalWidth;
-      canvas.height = img.naturalHeight;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) throw new Error("Canvas not supported");
-      ctx.drawImage(img, 0, 0);
-      const blob = await new Promise<Blob | null>((resolve) =>
-        canvas.toBlob(resolve, item.file.type || "image/jpeg", quality),
-      );
-      if (!blob) throw new Error("Compression failed");
-      const copy: Item = { ...item };
-      copy.compressedSize = blob.size;
-      if (!previewOnly) {
-        if (copy.compressedUrl) URL.revokeObjectURL(copy.compressedUrl);
-        copy.compressedUrl = URL.createObjectURL(blob);
-      }
-      updated.push(copy);
-      await new Promise((r) => setTimeout(r, 0));
+  const handleFiles = (files: FileList) => {
+    const f = files[0];
+    if (!f) return;
+    if (!f.type.match(/image\/(jpeg|png)/)) {
+      alert("Please upload a JPEG or PNG image.");
+      return;
     }
-    setItems(updated);
+    const reader = new FileReader();
+    reader.onload = () => {
+      const url = reader.result as string;
+      setOriginalUrl(url);
+      setOriginalSize(f.size);
+      setCompressedUrl(null);
+      setCompressedSize(0);
+      setFile(f);
+      const img = new Image();
+      img.onload = () => setDimensions({ w: img.naturalWidth, h: img.naturalHeight });
+      img.src = url;
+    };
+    reader.readAsDataURL(f);
+  };
+
+  const compress = async () => {
+    if (!file || !originalUrl) return;
+    setProcessing(true);
+    await new Promise(requestAnimationFrame);
+    const img = new Image();
+    img.src = originalUrl;
+    await new Promise<void>((res, rej) => {
+      img.onload = () => res();
+      img.onerror = () => rej(new Error("load"));
+    });
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      setProcessing(false);
+      return;
+    }
+    ctx.drawImage(img, 0, 0);
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, "image/jpeg", quality)
+    );
+    if (!blob) {
+      setProcessing(false);
+      return;
+    }
+    if (compressedUrl) URL.revokeObjectURL(compressedUrl);
+    setCompressedUrl(URL.createObjectURL(blob));
+    setCompressedSize(blob.size);
     setProcessing(false);
   };
 
-  useEffect(() => {
-    if (items.length) compressImages(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [quality]);
-
-  const download = (item: Item) => {
-    if (!item.compressedUrl) return;
+  const download = () => {
+    if (!compressedUrl || !file) return;
+    const extMatch = file.name.match(/\.\w+$/);
+    const ext = extMatch ? extMatch[0] : "";
     const a = document.createElement("a");
-    a.href = item.compressedUrl;
-    a.download = `compressed-${item.file.name}`;
+    a.href = compressedUrl;
+    a.download = file.name.replace(ext, `-compressed${ext}`);
     a.click();
   };
+
+  const reset = () => {
+    if (originalUrl && originalUrl.startsWith("blob:")) URL.revokeObjectURL(originalUrl);
+    if (compressedUrl) URL.revokeObjectURL(compressedUrl);
+    setFile(null);
+    setOriginalUrl(null);
+    setCompressedUrl(null);
+    setOriginalSize(0);
+    setCompressedSize(0);
+  };
+
+  const percentReduction = compressedSize
+    ? Math.max(0, (1 - compressedSize / originalSize) * 100)
+    : 0;
 
   return (
     <section
@@ -132,94 +129,116 @@ export default function ImageCompressorClient() {
         Image Compressor
       </h1>
       <p className="text-center text-gray-600 mb-8 max-w-2xl mx-auto leading-relaxed">
-        Upload images, adjust quality and download smaller files. 100%
-        client-side, no signup required.
+        Upload an image, adjust quality and compress it entirely in your browser.
+        No signup or server upload required.
       </p>
 
-      <div className="max-w-xl mx-auto mb-8">
-        <DropZone onFiles={handleFiles} />
-      </div>
+      {!file && (
+        <div className="max-w-lg mx-auto mb-8">
+          <DropZone onFiles={handleFiles} multiple={false} />
+        </div>
+      )}
 
-      {items.length > 0 && (
-        <>
-          <div className="max-w-xl mx-auto mb-8 space-y-4">
+      {file && (
+        <div className="space-y-8">
+          <div className="max-w-md mx-auto space-y-4">
             <div className="flex justify-center gap-2">
               {PRESETS.map((p) => (
                 <Button
                   key={p.label}
-                  onClick={() => setQuality(p.value)}
+                  onClick={() => {
+                    setSliderValue(Math.round(p.value * 100));
+                    setQuality(p.value);
+                  }}
                   className="px-4 py-2"
                 >
                   {p.label}
                 </Button>
               ))}
             </div>
-            <label
-              htmlFor="quality"
-              className="block font-medium text-gray-800"
-            >
-              Quality:{" "}
-              <span className="font-semibold">
-                {Math.round(quality * 100)}%
-              </span>
+            <label htmlFor="quality" className="block font-medium text-gray-800">
+              Quality: <span className="font-semibold">{sliderValue}%</span>
             </label>
             <input
               id="quality"
               type="range"
-              min={0.1}
-              max={1}
-              step={0.01}
-              value={quality}
-              onChange={(e) => setQuality(parseFloat(e.target.value))}
-              className="w-full"
+              min={1}
+              max={100}
+              step={1}
+              value={sliderValue}
+              onChange={(e) => setSliderValue(Number(e.target.value))}
+              aria-label="Image quality percentage"
+              className="w-full cursor-pointer"
             />
           </div>
 
-          <div className="text-center mb-8">
+          <div className="text-center">
             <Button
-              onClick={() => compressImages(false)}
+              onClick={compress}
               disabled={processing}
+              aria-label="Compress"
               className={processing ? "opacity-60 cursor-not-allowed" : ""}
             >
-              {processing ? "Compressing..." : "Compress Images"}
+              {processing ? (
+                <span className="flex items-center justify-center gap-2">
+                  <Spinner className="h-5 w-5" /> Compressing...
+                </span>
+              ) : (
+                "Compress"
+              )}
             </Button>
           </div>
 
-          {error && (
-            <div
-              role="alert"
-              className="max-w-md mx-auto mb-8 p-4 bg-red-50 border border-red-200 text-red-700 rounded-md"
-            >
-              {error}
+          <div className="flex flex-col sm:flex-row gap-8 justify-center mt-8">
+            {originalUrl && (
+              <div className="flex-1 text-center">
+                <PreviewImage
+                  src={originalUrl}
+                  alt="Original image preview"
+                  width={dimensions.w}
+                  height={dimensions.h}
+                />
+                <p className="mt-2 text-sm text-gray-600">
+                  Original – {(originalSize / 1024).toFixed(1)} KB
+                </p>
+              </div>
+            )}
+            {compressedUrl && (
+              <div className="flex-1 text-center">
+                <PreviewImage
+                  src={compressedUrl}
+                  alt="Compressed image preview"
+                  width={dimensions.w}
+                  height={dimensions.h}
+                />
+                <p className="mt-2 text-sm text-gray-600">
+                  Compressed – {(compressedSize / 1024).toFixed(1)} KB ({percentReduction.toFixed(1)}% reduction) @
+                  {" "}
+                  {Math.round(quality * 100)}% quality
+                </p>
+              </div>
+            )}
+          </div>
+
+          {compressedUrl && (
+            <div className="flex flex-wrap justify-center gap-4 mt-6">
+              <Button
+                onClick={download}
+                className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
+                aria-label="Download compressed image"
+              >
+                Download Compressed
+              </Button>
+              <button
+                onClick={reset}
+                className="text-indigo-600 underline hover:text-indigo-800 focus:outline-none"
+                aria-label="Reset"
+              >
+                Reset
+              </button>
             </div>
           )}
-
-          <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3 max-w-5xl mx-auto mb-8">
-            {items.map((item, idx) => (
-              <div key={idx} className="text-center space-y-2">
-                <PreviewImage
-                  src={item.compressedUrl ?? item.originalUrl}
-                  alt={`${item.compressedUrl ? "Compressed" : "Original"} image ${idx + 1}`}
-                  width={item.width}
-                  height={item.height}
-                />
-                <p className="text-sm text-gray-600">
-                  {(item.originalSize / 1024).toFixed(1)} KB
-                  {item.compressedSize != null &&
-                    ` → ${(item.compressedSize / 1024).toFixed(1)} KB`}
-                </p>
-                {item.compressedUrl && (
-                  <Button
-                    onClick={() => download(item)}
-                    className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
-                  >
-                    Download
-                  </Button>
-                )}
-              </div>
-            ))}
-          </div>
-        </>
+        </div>
       )}
     </section>
   );

--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useRef, useState } from "react";
 
-export default function DropZone({ onFiles }: { onFiles: (files: FileList) => void }) {
+export default function DropZone({ onFiles, multiple = false }: { onFiles: (files: FileList) => void; multiple?: boolean }) {
   const [dragging, setDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -15,7 +15,7 @@ export default function DropZone({ onFiles }: { onFiles: (files: FileList) => vo
     <div
       role="button"
       tabIndex={0}
-      aria-label="Drag and drop images or browse"
+      aria-label={`Drag and drop ${multiple ? "images" : "image"} or browse`}
       onClick={() => inputRef.current?.click()}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
@@ -33,13 +33,13 @@ export default function DropZone({ onFiles }: { onFiles: (files: FileList) => vo
       className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 ${dragging ? "bg-indigo-50" : "bg-white"}`}
     >
       <p className="text-gray-700">
-        Drag & drop images or <span className="text-indigo-600 underline">browse</span>
+        Drag & drop {multiple ? "images" : "image"} or <span className="text-indigo-600 underline">browse</span>
       </p>
       <input
         ref={inputRef}
         type="file"
         accept="image/*"
-        multiple
+        multiple={multiple}
         onChange={(e) => handleFiles(e.target.files)}
         className="hidden"
       />


### PR DESCRIPTION
## Summary
- enhance `DropZone` with optional multiple file support
- rewrite image compressor client UI for single-image workflow

## Testing
- `npm test`
- `npm run -s build`

------
https://chatgpt.com/codex/tasks/task_e_6872bb62e2708325a2eea3af71ae896f