### PR TITLE
Clarify palette count persistence

### DIFF
--- a/COLOR_PALETTE_DEV_PROMPT.md
+++ b/COLOR_PALETTE_DEV_PROMPT.md
@@ -1,0 +1,1 @@
+On any user interaction (base color or scheme change), generate exactly N colors. The value N comes from the "Colors" slider and must remain unchanged when the user switches schemes or edits the base color.

--- a/app/tools/color-palette-generator/color-palette-generator-client.tsx
+++ b/app/tools/color-palette-generator/color-palette-generator-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 // On any user interaction (base color or scheme change), generate exactly N colors.
-// This is a hard requirement: N comes from the "Colors" control and must persist
-// across interactions without resetting.
+// N is set by the "Colors" slider and must never reset when switching schemes or
+// editing the base color.
 import { useState, ChangeEvent, useEffect } from "react";
 import Input from "@/components/Input";
 import {


### PR DESCRIPTION
## Summary
- clarify requirement for keeping palette count on scheme or base color changes
- add `COLOR_PALETTE_DEV_PROMPT.md` dev note for the generator

## Testing
- `npm test`
- `npm run test:e2e` *(fails: unable to execute playwright tests)*

------
https://chatgpt.com/codex/tasks/task_e_6872c129921c8325841b77f061f3885b