### PR TITLE
Ensure unique keys for palette swatches

### DIFF
--- a/app/tools/color-palette-generator/color-palette-generator-client.tsx
+++ b/app/tools/color-palette-generator/color-palette-generator-client.tsx
@@ -174,12 +174,12 @@ export default function ColorPaletteGeneratorClient() {
       </div>
       {palette.length > 0 && (
         <div className="mt-12 flex flex-wrap justify-center gap-4">
-          {palette.map((hex) => {
+          {palette.map((hex, idx) => {
             const rgb = hexToRgb(hex)!;
             const hsl = rgbToHsl(rgb);
             return (
               <div
-                key={hex}
+                key={`${hex}-${idx}`}
                 role="button"
                 aria-label={`Color ${hex}`}
                 onClick={() => navigator.clipboard.writeText(hex)}


### PR DESCRIPTION
## Summary
- ensure each swatch element has a unique key so all `count` swatches render reliably

## Testing
- `npm test -- __tests__/color-palette.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6872e525d0408325b829cffbdd1ca879